### PR TITLE
mosquitto: enable persistence on NFS-backed PV

### DIFF
--- a/mosquitto/Chart.yaml
+++ b/mosquitto/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mosquitto
-version: 1.0.0
+version: 1.1.0
 home: https://mosquitto.or
 type: application
 # renovate: image=eclipse-mosquitto

--- a/mosquitto/README.md
+++ b/mosquitto/README.md
@@ -10,4 +10,21 @@ helm install mosquitto .
 ## Helm unintall
 ```
 helm uninstall mosquitto
-``` 
+```
+
+## Persistence
+Retained messages (e.g. Home Assistant MQTT discovery configs) are persisted to `/mosquitto/data` on an NFS-backed PV (`/nfs/mosquitto`), so they survive pod restarts and rescheduling.
+
+Create the NFS directory once on the NFS server:
+```
+sudo mkdir /nfs/mosquitto
+sudo chown -R nobody:nogroup /nfs/mosquitto
+```
+
+### Verify
+```
+kubectl rollout restart deployment mosquitto
+kubectl rollout status deployment mosquitto
+mosquitto_sub -h 192.168.1.27 -t 'homeassistant/#' -v -W 5
+```
+The retained discovery configs must still be delivered after the restart.

--- a/mosquitto/templates/configmap.yaml
+++ b/mosquitto/templates/configmap.yaml
@@ -10,5 +10,8 @@ data:
     listener 8083
     protocol websockets
     allow_anonymous true
+    persistence true
+    persistence_location /mosquitto/data/
+    autosave_interval 60
     log_timestamp true
     log_timestamp_format %Y-%m-%d %H:%M:%S

--- a/mosquitto/templates/deploy.yaml
+++ b/mosquitto/templates/deploy.yaml
@@ -35,7 +35,12 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /mosquitto/config
+            - name: data
+              mountPath: /mosquitto/data
       volumes:
         - name: config
           configMap:
             name: mosquitto
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}

--- a/mosquitto/templates/pv.yaml
+++ b/mosquitto/templates/pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ .Values.nfs.server }}
+    path: {{ .Values.nfs.path }}

--- a/mosquitto/templates/pvc.yaml
+++ b/mosquitto/templates/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  storageClassName: ""
+  volumeName: mosquitto
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/mosquitto/values.yaml
+++ b/mosquitto/values.yaml
@@ -3,3 +3,6 @@ image:
   tag: 2.0.22@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c
 service:
   loadBalancerIPs: 192.168.1.27
+nfs:
+  server: 192.168.1.5
+  path: /nfs/mosquitto


### PR DESCRIPTION
## Summary

Closes #2259

The mosquitto broker ran without persistence, so every broker pod restart (node reboot, rollout, rescheduling) wiped all retained MQTT messages — including the Home Assistant MQTT discovery configs (`homeassistant/.../config`).

This PR enables broker persistence backed by an NFS PersistentVolume, following the same PV/PVC pattern already used by the evcc/adguard/grafana charts:

- **`mosquitto.conf`**: adds `persistence true`, `persistence_location /mosquitto/data/`, `autosave_interval 60`
- **`templates/pv.yaml`** (new): 1Gi NFS-backed PersistentVolume (`/nfs/mosquitto` on `192.168.1.5`), `persistentVolumeReclaimPolicy: Retain`
- **`templates/pvc.yaml`** (new): PVC bound to the PV via `volumeName`
- **`templates/deploy.yaml`**: mounts the PVC at `/mosquitto/data` (deployment already uses `strategy: Recreate`, which fits the RWO claim)
- **`values.yaml`**: adds `nfs.server` / `nfs.path`
- **`README.md`**: documents the one-time NFS directory setup and how to verify retained messages survive a broker restart
- **`Chart.yaml`**: version bump `1.0.0` → `1.1.0`

## Acceptance criteria (from the issue)

- [x] `persistence true` + `persistence_location` in the mosquitto config
- [x] Persistence directory on a persistent volume (PVC/NFS)
- [ ] Verify after merge: restart the broker pod and confirm the retained `homeassistant/#` discovery configs are still delivered (steps in the chart README)

## Notes for deployment

The NFS directory must exist on the NFS server before the pod can start:

```
sudo mkdir /nfs/mosquitto
sudo chown -R nobody:nogroup /nfs/mosquitto
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eDn6WHaiLb1nERK6vtS6v

---
_Generated by [Claude Code](https://claude.ai/code/session_015eDn6WHaiLb1nERK6vtS6v)_