### PR TITLE
telegraf: Daikin Modbus input (scaffold, inactive)

### DIFF
--- a/telegraf/DAIKIN-MODBUS.md
+++ b/telegraf/DAIKIN-MODBUS.md
@@ -1,0 +1,64 @@
+# Daikin Altherma — Modbus integration (scaffold)
+
+Prepared, **inactive** scaffold for the heat pump's Telegraf Modbus input
+(Daikin Altherma 3 R: ERGA04-08E / ETBH12E / EKHWSP, Home Hub **EKRHH**).
+While `daikin.enabled: false`, **nothing** is deployed — merging this PR does not
+change the running cluster.
+
+Related analysis project: `~/Projects/waermepumpe-vs-gas/` (metric names live in
+`analyse/vergleich_run.py`, e.g. `daikin_energy_input`, `daikin_heat_output`).
+
+## What already exists
+- `templates/configmap-daikin.yaml` — ConfigMap `telegraf-modbus-daikin` with
+  `daikin.conf` (Modbus input skeleton, registers are PLACEHOLDERS). Gated by
+  `{{ if .Values.daikin.enabled }}`.
+- `values.yaml` — `daikin.enabled: false` plus commented-out activation blocks
+  (env `DAIKIN_MODBUS_CONTROLLER`, volume, mountPoint, `--config-directory`).
+
+## Activation (after the heat pump is commissioned)
+
+1. **Map the registers.** Fill the real values from the EKRHH / Daikin Modbus
+   documentation into `templates/configmap-daikin.yaml` (slave_id, address, type, scale,
+   byte_order, register type) and uncomment the `fields` lines. Clarify the connection:
+   **Modbus TCP** (`tcp://<home-hub-ip>:502`) or **RTU/RS485** (`file:///dev/ttyUSB0` +
+   baud/parity).
+2. **Uncomment in values.yaml:** enable the four `# Daikin (scaffold)` blocks
+   (env, `--config-directory /etc/telegraf/daikin.d`, volume, mountPoint) and set
+   `DAIKIN_MODBUS_CONTROLLER`.
+3. **Set `daikin.enabled: true`.**
+
+> The Daikin only reports *estimated* energy values. For a reliable COP/SCOP figure, add a
+> calibrated heat meter + a dedicated electricity meter (separate Modbus/S0 input, same
+> pattern). See `waermepumpe-vs-gas/modbus-monitoring.md`.
+
+## Testing — do the Modbus imports work?
+
+The pattern is **already proven in production**: the FoxESS inverter runs over the same
+`[[inputs.modbus]]` path (`configmap.yaml` -> VictoriaMetrics `foxess_*`). For the Daikin, verify:
+
+1. **Check rendering (no cluster needed):**
+   ```bash
+   helm template telegraf ./telegraf --set daikin.enabled=true \
+     -s templates/configmap-daikin.yaml
+   ```
+2. **Dry run against the unit** (before writing to VM): in `values.yaml` under
+   `config.outputs` temporarily enable the `file` output (stdout) with `namepass = ["daikin"]`
+   and `config.agent.debug: true`. Then read the pod logs:
+   ```bash
+   kubectl -n default logs deploy/telegraf -f | grep -i -E "daikin|modbus"
+   ```
+   Expected: no Modbus errors (timeouts / CRC / illegal address) and `daikin_*` lines in the log.
+   On `illegal data address` -> fix register/offset/register type (holding vs input).
+   On CRC/timeout -> check the connection (TCP IP/port or RTU baud/parity/slave_id).
+3. **Arriving in VictoriaMetrics:**
+   ```bash
+   kubectl -n default exec deploy/grafana -- sh -c \
+     "curl -s 'http://vmsingle-vm:8428/api/v1/query' --data-urlencode 'query=daikin_energy_input' -G"
+   ```
+4. **End-to-end:** in the WP project run `python3 analyse/vergleich_run.py --since 7` — the heat
+   pump section now shows JAZ/COP instead of "no Modbus data yet".
+
+## Afterwards
+- Align the metric names in `waermepumpe-vs-gas/analyse/vergleich_run.py` with the real fields.
+- Create a Grafana dashboard "Wärmepumpe" analogous to `ems-esp-heizung`.
+- Merge `daikin.enabled: true` to main -> ArgoCD deploys the input.

--- a/telegraf/templates/configmap-daikin.yaml
+++ b/telegraf/templates/configmap-daikin.yaml
@@ -1,0 +1,90 @@
+{{- /*
+  SCAFFOLD — Daikin Altherma 3 R (Home Hub EKRHH) Modbus input for Telegraf.
+
+  Renders ONLY when `daikin.enabled: true` is set (default: false).
+  This keeps it inert after a merge, until the heat pump is installed and the
+  registers are filled in from the EKRHH / Daikin Modbus documentation.
+
+  Activation (after commissioning, see telegraf/DAIKIN-MODBUS.md):
+    1. Fill in the real registers below (slave_id/address/type/scale/byte_order)
+    2. In values.yaml: set daikin.enabled=true and uncomment DAIKIN_MODBUS_CONTROLLER,
+       the volume, the mountPoint and `--config-directory /etc/telegraf/daikin.d`
+    3. Test against the unit first (debug/file output), then write to VictoriaMetrics
+*/ -}}
+{{- if .Values.daikin.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telegraf-modbus-daikin
+  labels:
+    app.kubernetes.io/name: telegraf
+data:
+  daikin.conf: |
+    # =====================================================================
+    # Daikin Altherma 3 R — ERGA04-08E / ETBH12E / EKHWSP via Home Hub EKRHH
+    # PLACEHOLDERS: fill slave_id, address, type, scale, byte_order from the
+    # EKRHH / Daikin Modbus documentation. Metric names are chosen to match
+    # analyse/vergleich_run.py in the WP project
+    # (daikin_energy_input, daikin_heat_output, daikin_compressor_starts, ...).
+    # =====================================================================
+    [[inputs.modbus]]
+      name = "daikin"
+      # RTU (RS485):  file:///dev/ttyUSB0   |  TCP:  tcp://<home-hub-ip>:502
+      controller = "${DAIKIN_MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "30s"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      # RTU parameters only needed for a serial connection (TODO: verify):
+      # baud_rate = 9600
+      # data_bits = 8
+      # parity = "N"
+      # stop_bits = 1
+      [inputs.modbus.tags]
+        device = "daikin_altherma_3r"
+
+      # -- Energy (lifetime counters, kWh) ------------------------------
+      # -> daikin_energy_input (electricity in), daikin_energy_heat_output (heat out)
+      #    Basis for COP/SCOP = heat_output / energy_input.
+      [[inputs.modbus.request]]
+        slave_id = 1              # TODO: real slave ID (Daikin address)
+        byte_order = "ABCD"       # TODO: verify (AB | BA | ABCD | CDAB | DCBA)
+        register = "holding"      # TODO: holding | input
+        measurement = "daikin"
+        # TODO: fill in real registers, then uncomment:
+        fields = [
+          # {name = "energy_input",  address = 0, type = "UINT32", scale = 0.1},  # kWh electricity
+          # {name = "heat_output",   address = 0, type = "UINT32", scale = 0.1},  # kWh heat
+          # {name = "energy_dhw",    address = 0, type = "UINT32", scale = 0.1},  # kWh DHW share
+        ]
+
+      # -- Temperatures (deg C) -----------------------------------------
+      # -> daikin_flow_temp, daikin_return_temp, daikin_outdoor_temp, daikin_dhw_tank_temp
+      [[inputs.modbus.request]]
+        slave_id = 1              # TODO
+        byte_order = "AB"         # TODO
+        register = "holding"      # TODO
+        measurement = "daikin"
+        fields = [
+          # {name = "flow_temp",     address = 0, type = "INT16", scale = 0.1},
+          # {name = "return_temp",   address = 0, type = "INT16", scale = 0.1},
+          # {name = "outdoor_temp",  address = 0, type = "INT16", scale = 0.1},
+          # {name = "dhw_tank_temp", address = 0, type = "INT16", scale = 0.1},
+        ]
+
+      # -- Status / operation -------------------------------------------
+      # -> daikin_power_input (W), daikin_compressor_modulation (%),
+      #    daikin_compressor_starts (n), daikin_defrost_active (0/1)
+      [[inputs.modbus.request]]
+        slave_id = 1              # TODO
+        byte_order = "ABCD"       # TODO
+        register = "holding"      # TODO
+        measurement = "daikin"
+        fields = [
+          # {name = "power_input",           address = 0, type = "INT32",  scale = 1.0},
+          # {name = "compressor_modulation", address = 0, type = "UINT16", scale = 1.0},
+          # {name = "compressor_starts",     address = 0, type = "UINT32", scale = 1.0},
+          # {name = "defrost_active",        address = 0, type = "UINT16", scale = 1.0},
+        ]
+{{- end }}

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -1,3 +1,9 @@
+# Daikin heat pump (Modbus scaffold) — set to true once the heat pump is installed
+# and the registers in templates/configmap-daikin.yaml are mapped.
+# Step-by-step activation: telegraf/DAIKIN-MODBUS.md
+daikin:
+  enabled: false
+
 telegraf:
   service:
     enabled: false
@@ -8,6 +14,9 @@ telegraf:
       value: "http://vmsingle-vm:8428"
     - name: MODBUS_CONTROLLER
       value: "tcp://192.168.107.186:502"
+    # Daikin Home Hub (scaffold) — uncomment on activation:
+    # - name: DAIKIN_MODBUS_CONTROLLER
+    #   value: "tcp://<home-hub-ip>:502"   # or RTU: file:///dev/ttyUSB0
 
   config:
     agent:
@@ -91,12 +100,22 @@ telegraf:
     - /etc/telegraf/telegraf.conf
     - --config-directory
     - /etc/telegraf/conf.d
+    # Daikin (scaffold) — uncomment on activation:
+    # - --config-directory
+    # - /etc/telegraf/daikin.d
 
   volumes:
     - name: telegraf-modbus
       configMap:
         name: telegraf-modbus
+    # Daikin (scaffold) — uncomment on activation:
+    # - name: telegraf-modbus-daikin
+    #   configMap:
+    #     name: telegraf-modbus-daikin
 
   mountPoints:
     - name: telegraf-modbus
       mountPath: /etc/telegraf/conf.d
+    # Daikin (scaffold) — uncomment on activation:
+    # - name: telegraf-modbus-daikin
+    #   mountPath: /etc/telegraf/daikin.d


### PR DESCRIPTION
## What
Prepared **inactive scaffold** for the Modbus integration of the new heat pump
(Daikin Altherma 3 R — ERGA04-08E / ETBH12E / EKHWSP, Home Hub **EKRHH**) into
Telegraf → VictoriaMetrics, analogous to the existing FoxESS Modbus input.

## Safe to merge — deploys nothing
- The new ConfigMap `telegraf-modbus-daikin` is gated by `{{ if .Values.daikin.enabled }}`,
  default **`daikin.enabled: false`** → renders nothing, ArgoCD deploys nothing.
- Activation blocks in `values.yaml` (env, volume, mountPoint, `--config-directory`) are
  commented out. Registers in the ConfigMap are **placeholders** (TODO).

## Validation
- `helm template` default: the Daikin ConfigMap is **not** created; FoxESS unchanged.
- `helm template --set daikin.enabled=true` renders a valid ConfigMap
  (`kubectl apply --dry-run=client` OK).

## When to implement
After the heat pump is installed (**2026-07-20**): map the registers from the EKRHH docs,
uncomment the `values.yaml` blocks, set `daikin.enabled: true`, test against the unit
(debug/file output → `daikin_*` in VM). Step by step: `telegraf/DAIKIN-MODBUS.md`.

Metric names match the analysis project `~/Projects/waermepumpe-vs-gas/`
(`analyse/vergleich_run.py`).

**Draft** until the heat pump is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)