### PR TITLE
telegraf: fix FoxESS battery-power sign comment, drop dead remain_energy register

### DIFF
--- a/telegraf/templates/configmap.yaml
+++ b/telegraf/templates/configmap.yaml
@@ -130,8 +130,9 @@ data:
           {name = "temp_min",      address = 37618, type = "INT16",  scale = 0.1},
           {name = "cell_v_max",    address = 37619, type = "UINT16", scale = 1.0},
           {name = "cell_v_min",    address = 37620, type = "UINT16", scale = 1.0},
-          # Verbleibende Energie / Kapazität (Wh; gain=0.1 → scale=10.0)
-          {name = "remain_energy", address = 37632, type = "UINT16", scale = 10.0},
+          # remain_energy (37632) entfernt: BMS meldet konstant design_energy
+          # unabhängig vom SoC → keine Aussagekraft (Restenergie via soc/100 * design_energy ableiten)
+          # Full Charge Capacity (Ah; gain=10 → scale=0.1)
           {name = "fcc_capacity",  address = 37633, type = "UINT16", scale = 0.1},
           # Design-Energie (Wh; gain=0.1 → scale=10.0)
           {name = "design_energy", address = 37635, type = "UINT16", scale = 10.0}
@@ -139,7 +140,8 @@ data:
 
       # ── Batterie Wechselrichter-seitig (39xxx) ────────────────────────────
       # Tab. 3-5: Spannung, Strom, Leistung vom Wechselrichter gemessen
-      # Vorzeichen: positiv = Laden, negativ = Entladen
+      # Vorzeichen (WR-seitig, Protokoll 39228/39237): positiv = Entladen, negativ = Laden
+      #   Achtung: Gegenkonvention zur BMS-Strommessung (37610: positiv = Laden)
       [[inputs.modbus.request]]
         slave_id = 247
         byte_order = "ABCD"


### PR DESCRIPTION
## Summary

Full audit of the Telegraf FoxESS H3 Modbus config against the official protocol spec (**V1.05.04.00**) and against the live values written to VictoriaMetrics. **All register addresses, data types and scales are correct** — this PR only fixes a misleading comment and removes one register that carries no information on this hardware.

## Changes

**1. Battery-power sign comment (`foxess_battery` block)**
The comment claimed `positiv = Laden, negativ = Entladen`. Protocol registers 39228 (Battery1 Current) and 39237 (Battery Combined Power) both specify `>0 discharge, <0 charge`, and the live data confirms it: while SoC rose 15 % → 88 % (charging), `foxess_battery_power` read **−2105 … −4816 W** and `foxess_battery_bms_current` read **+10 … +23 A**. So the inverter-side registers are **positive = discharge** — the exact opposite of the old comment. Note the BMS current (37610) uses the *inverse* convention (positive = charge); the corrected comment now documents both.

**2. Remove `remain_energy` (BMS register 37632)**
`foxess_battery_bms_remain_energy` was stuck at a constant **23040 Wh (= design_energy)** for 24 h while SoC swung 15 % → 88 %. The BMS returns the same raw value as the design-energy register, so the metric is meaningless on this battery. Remaining energy can instead be derived at query time from `soc/100 * design_energy`.

## Not changed (verified correct)

Every other field — grid meter (388xx), grid/inverter AC (391xx), PV, BMS, inverter-side battery, and all energy totalisers (396xx) — matches the spec exactly (address, `INT/UINT` signedness, and `scale = 1/Gain`). Grid-meter sign convention independently confirmed against the Shelly Pro 3EM. Load balance holds end-to-end: `inverter_active_power + grid_import ≈ load_power`.

## Validation

- Embedded TOML parses cleanly (no trailing-comma issues); 7 request blocks intact.
- `helm template telegraf ./telegraf -s templates/configmap.yaml` renders successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)