### PR TITLE
feat(victoria-metrics): add Model Context Protocol (MCP) server support

### DIFF
--- a/victoria-metrics/templates/mcp-deployment.yaml
+++ b/victoria-metrics/templates/mcp-deployment.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: victoria-metrics-mcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: victoria-metrics-mcp
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.mcp.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: victoria-metrics-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: victoria-metrics-mcp
+    spec:
+      containers:
+        - name: mcp
+          image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag }}"
+          imagePullPolicy: {{ .Values.mcp.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: VM_INSTANCE_ENTRYPOINT
+              value: "http://vmsingle-vm:8428"
+            - name: VM_INSTANCE_TYPE
+              value: "{{ .Values.mcp.vmInstanceType }}"
+            - name: MCP_SERVER_MODE
+              value: "{{ .Values.mcp.serverMode }}"
+            - name: MCP_LISTEN_ADDR
+              value: "{{ .Values.mcp.listenAddr }}"
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+{{- end }}

--- a/victoria-metrics/templates/mcp-ingress.yaml
+++ b/victoria-metrics/templates/mcp-ingress.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.mcp.enabled .Values.mcp.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: victoria-metrics-mcp
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- toYaml .Values.mcp.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.mcp.ingress.ingressClassName }}
+  rules:
+    {{- range .Values.mcp.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: victoria-metrics-mcp
+                port:
+                  number: 8080
+          {{- end }}
+    {{- end }}
+  {{- if .Values.mcp.ingress.tls }}
+  tls:
+    {{- toYaml .Values.mcp.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/victoria-metrics/templates/mcp-service.yaml
+++ b/victoria-metrics/templates/mcp-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: victoria-metrics-mcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: victoria-metrics-mcp
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: victoria-metrics-mcp
+{{- end }}

--- a/victoria-metrics/values.yaml
+++ b/victoria-metrics/values.yaml
@@ -93,3 +93,29 @@ victoria-metrics:
       selectAllByDefault: true
       extraArgs:
         promscrape.streamParse: "true"
+
+mcp:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/victoriametrics/mcp-victoriametrics
+    tag: v1.20.2
+    pullPolicy: IfNotPresent
+  serverMode: sse
+  listenAddr: ":8080"
+  vmInstanceType: single
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      traefik.ingress.kubernetes.io/router.middlewares: default-https-redirect@kubernetescrd
+    hosts:
+      - host: mcp-vm.burau.dev
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: cloudflare-tls
+        hosts:
+          - mcp-vm.burau.dev
+


### PR DESCRIPTION
This Pull Request introduces Model Context Protocol (MCP) support for our self-hosted VictoriaMetrics instance (`vmsingle-vm`) inside the Kubernetes cluster.

### Description
The official `mcp-victoriametrics` server is deployed as a new component inside the `victoria-metrics` wrapper Helm chart. It serves as a bridge allowing AI assistants and coding agents (e.g. Claude Desktop or other MCP-compatible clients) to query metrics, search embedded documentation, and perform troubleshooting on the database using natural language.

### Changes Made
1. **`victoria-metrics/values.yaml`**: Added configuration for the MCP server. Set the container image to `ghcr.io/victoriametrics/mcp-victoriametrics:v1.20.2`, set the mode to `sse`, and defined external exposure parameters via Ingress.
2. **`victoria-metrics/templates/mcp-deployment.yaml`**: Created the deployment manifest. Connected internally to `http://vmsingle-vm:8428`. Configured liveness and readiness probes on `/health/liveness` and `/health/readiness`. Increased the resource limits to `1000m` CPU and `2Gi` memory, with increased probe thresholds, to avoid `OOMKilled` crashes and handle the 40-second Bleve indexing initialization time on the Raspberry Pi node.
3. **`victoria-metrics/templates/mcp-service.yaml`**: Created a `ClusterIP` Service exposing port `8080` internally.
4. **`victoria-metrics/templates/mcp-ingress.yaml`**: Created a Traefik Ingress resource pointing `mcp-vm.burau.dev` to the service, leveraging TLS through the `cloudflare-tls` secret.

### Verification and Testing
- Rendered templates via `helm template` to check syntax.
- Validated resources via a dry-run kubectl command (`kubectl apply --dry-run=client -f -`).
- Upgraded the Helm release in the cluster:
  ```bash
  helm upgrade --install victoria-metrics . --take-ownership --force-conflicts
  ```
- Checked pod status (`1/1 READY`) and logs showing successful Bleve startup and HTTP listening.
- Successfully verified the external Traefik ingress using curl (returned 200 OK with `OK` and `Ready` status on `/health/*` endpoints).
