### PR TITLE
fix(victoria-metrics): switch MCP serverMode to http

### DIFF
--- a/victoria-metrics/values.yaml
+++ b/victoria-metrics/values.yaml
@@ -101,7 +101,7 @@ mcp:
     repository: ghcr.io/victoriametrics/mcp-victoriametrics
     tag: v1.120.1@sha256:16d9a30a6629319a8e84a73b9b54e1e9b9e5bf229bc40a7f1717c8602b0c1c09
     pullPolicy: IfNotPresent
-  serverMode: sse
+  serverMode: http
   listenAddr: ":8080"
   vmInstanceType: single
   ingress:


### PR DESCRIPTION
This Pull Request switches the MCP server mode from sse to http. This enables the Streamable HTTP transport mode, exposing the MCP server at /mcp and the SPA UI at /, aligning with the modern MCP specification (which deprecated SSE in March 2025 in favor of Streamable HTTP). This resolves issues where clients connecting via Streamable HTTP received 404 errors on the /mcp endpoint.