### PR TITLE
feat: add victoria-logs as standalone helm chart

### DIFF
--- a/argocd/templates/victoria-logs.yaml
+++ b/argocd/templates/victoria-logs.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: victoria-logs
+  namespace: default
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: victoria-logs
+    repoURL: https://github.com/0Bu/rpi-k3s-cluster.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - RespectIgnoreDifferences=true
+      - ServerSideApply=true

--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -18,3 +18,13 @@ grafana:
     existingClaim: grafana
   plugins:
     - volkovlabs-echarts-panel
+    - victoriametrics-logs-datasource
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: VictoriaLogs
+          type: victoriametrics-logs-datasource
+          access: proxy
+          url: http://vlogs:9428
+          isDefault: false

--- a/victoria-logs/Chart.lock
+++ b/victoria-logs/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: victoria-logs-single
+  repository: https://victoriametrics.github.io/helm-charts/
+  version: 0.13.8
+digest: sha256:a2c8110db0a751e54aac60e545c422fb8628841601c85198fb035e5b68bfef28
+generated: "2026-07-15T13:45:58.260265+02:00"

--- a/victoria-logs/Chart.yaml
+++ b/victoria-logs/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: victoria-logs
+type: application
+version: 1.0.0
+appVersion: "v1.51.0"
+dependencies:
+  - name: victoria-logs-single
+    alias: victoria-logs
+    version: "0.13.8"
+    repository: https://victoriametrics.github.io/helm-charts/

--- a/victoria-logs/README.md
+++ b/victoria-logs/README.md
@@ -1,0 +1,12 @@
+# [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/)
+- [Helm Chart](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-logs-single)
+
+## Helm install
+```
+helm install victoria-logs .
+```
+
+## Helm uninstall
+```
+helm uninstall victoria-logs
+```

--- a/victoria-logs/templates/pv.yaml
+++ b/victoria-logs/templates/pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: victoria-logs
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ .Values.nfs.server }}
+    path: {{ .Values.nfs.path }}

--- a/victoria-logs/templates/pvc.yaml
+++ b/victoria-logs/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: victoria-logs
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/victoria-logs/values.yaml
+++ b/victoria-logs/values.yaml
@@ -1,0 +1,36 @@
+nfs:
+  server: 192.168.1.5
+  path: /nfs/victoria-logs
+
+victoria-logs:
+  server:
+    fullnameOverride: vlogs
+    retentionPeriod: 1 # 1 month retention
+    
+    persistentVolume:
+      enabled: true
+      existingClaim: "victoria-logs"
+      
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      annotations:
+        traefik.ingress.kubernetes.io/router.middlewares: default-https-redirect@kubernetescrd
+      hosts:
+        - name: victoria-logs.burau.dev
+          path:
+            - /
+          port: http
+        - name: logs.burau.dev
+          path:
+            - /
+          port: http
+      tls:
+        - secretName: cloudflare-tls
+          hosts:
+            - victoria-logs.burau.dev
+            - logs.burau.dev
+
+  # Enable log collection via vector
+  vector:
+    enabled: true


### PR DESCRIPTION
Adds VictoriaLogs as a standalone Helm chart next to victoria-metrics with subdomains, NFS persistence, Vector collector, and Grafana integration.