### PR TITLE
feat(victoria-logs): add mcp-victorialogs server

### DIFF
--- a/victoria-logs/templates/mcp-deployment.yaml
+++ b/victoria-logs/templates/mcp-deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: victoria-logs-mcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: victoria-logs-mcp
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.mcp.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: victoria-logs-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: victoria-logs-mcp
+    spec:
+      containers:
+        - name: mcp
+          image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag }}"
+          imagePullPolicy: {{ .Values.mcp.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: VL_INSTANCE_ENTRYPOINT
+              value: "http://vlogs:9428"
+            - name: MCP_SERVER_MODE
+              value: "{{ .Values.mcp.serverMode }}"
+            - name: MCP_LISTEN_ADDR
+              value: "{{ .Values.mcp.listenAddr }}"
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+{{- end }}

--- a/victoria-logs/templates/mcp-ingress.yaml
+++ b/victoria-logs/templates/mcp-ingress.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.mcp.enabled .Values.mcp.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: victoria-logs-mcp
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- toYaml .Values.mcp.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.mcp.ingress.ingressClassName }}
+  rules:
+    {{- range .Values.mcp.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: victoria-logs-mcp
+                port:
+                  number: 8080
+          {{- end }}
+    {{- end }}
+  {{- if .Values.mcp.ingress.tls }}
+  tls:
+    {{- toYaml .Values.mcp.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/victoria-logs/templates/mcp-service.yaml
+++ b/victoria-logs/templates/mcp-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: victoria-logs-mcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: victoria-logs-mcp
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: victoria-logs-mcp
+{{- end }}

--- a/victoria-logs/values.yaml
+++ b/victoria-logs/values.yaml
@@ -49,3 +49,27 @@ victoria-logs:
       limits:
         cpu: 200m
         memory: 128Mi
+
+mcp:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/victoriametrics/mcp-victorialogs
+    tag: v1.9.0
+    pullPolicy: IfNotPresent
+  serverMode: http
+  listenAddr: ":8080"
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      traefik.ingress.kubernetes.io/router.middlewares: default-https-redirect@kubernetescrd
+    hosts:
+      - host: mcp-logs.burau.dev
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: cloudflare-tls
+        hosts:
+          - mcp-logs.burau.dev


### PR DESCRIPTION
Adds the mcp-victorialogs server deployment, service, and ingress (mcp-logs.burau.dev) to the victoria-logs wrapper Helm chart.