### PR TITLE
feat(victoria-logs): enable syslog ingestion via Vector LoadBalancer

### DIFF
--- a/victoria-logs/values.yaml
+++ b/victoria-logs/values.yaml
@@ -6,11 +6,11 @@ victoria-logs:
   server:
     fullnameOverride: vlogs
     retentionPeriod: 1 # 1 month retention
-    
+
     persistentVolume:
       enabled: true
       existingClaim: "victoria-logs"
-      
+
     resources:
       requests:
         cpu: 100m
@@ -18,7 +18,7 @@ victoria-logs:
       limits:
         cpu: "1"
         memory: 512Mi
-      
+
     ingress:
       enabled: true
       ingressClassName: traefik
@@ -63,10 +63,6 @@ victoria-logs:
       enabled: true
       type: LoadBalancer
       ports:
-        - name: prom-exporter
-          port: 9090
-          protocol: TCP
-          targetPort: 9090
         - name: syslog-udp
           port: 514
           protocol: UDP

--- a/victoria-logs/values.yaml
+++ b/victoria-logs/values.yaml
@@ -49,6 +49,77 @@ victoria-logs:
       limits:
         cpu: 200m
         memory: 128Mi
+    containerPorts:
+      - name: prom-exporter
+        containerPort: 9090
+        protocol: TCP
+      - name: syslog-udp
+        containerPort: 1514
+        protocol: UDP
+      - name: syslog-tcp
+        containerPort: 1514
+        protocol: TCP
+    service:
+      enabled: true
+      type: LoadBalancer
+      ports:
+        - name: prom-exporter
+          port: 9090
+          protocol: TCP
+          targetPort: 9090
+        - name: syslog-udp
+          port: 514
+          protocol: UDP
+          targetPort: 1514
+        - name: syslog-tcp
+          port: 514
+          protocol: TCP
+          targetPort: 1514
+    customConfig:
+      data_dir: /vector-data-dir
+      api:
+        enabled: false
+        address: 0.0.0.0:8686
+      sources:
+        k8s:
+          type: kubernetes_logs
+        internal_metrics:
+          type: internal_metrics
+        syslog_udp:
+          type: syslog
+          address: 0.0.0.0:1514
+          mode: udp
+        syslog_tcp:
+          type: syslog
+          address: 0.0.0.0:1514
+          mode: tcp
+      transforms:
+        parser:
+          type: remap
+          inputs: [k8s]
+          source: |
+            .log = parse_json(.message) ?? .message
+            del(.message)
+      sinks:
+        exporter:
+          type: prometheus_exporter
+          address: 0.0.0.0:9090
+          inputs: [internal_metrics]
+        vlogs:
+          type: elasticsearch
+          inputs: [parser, syslog_udp, syslog_tcp]
+          mode: bulk
+          api_version: v8
+          compression: gzip
+          healthcheck:
+            enabled: false
+          request:
+            headers:
+              VL-Time-Field: timestamp
+              VL-Stream-Fields: stream,kubernetes.pod_name,kubernetes.container_name,kubernetes.pod_namespace,hostname,appname,facility,severity,source_type
+              VL-Msg-Field: message,msg,_msg,log.msg,log.message,log
+              AccountID: "0"
+              ProjectID: "0"
 
 mcp:
   enabled: true

--- a/victoria-logs/values.yaml
+++ b/victoria-logs/values.yaml
@@ -62,6 +62,8 @@ victoria-logs:
     service:
       enabled: true
       type: LoadBalancer
+      annotations:
+        metallb.io/loadBalancerIPs: 192.168.1.22
       ports:
         - name: syslog-udp
           port: 514


### PR DESCRIPTION
Enables syslog ingestion into VictoriaLogs via the `victoria-logs-vector` Agent DaemonSet, exposing **only** syslog to the network.

### Changes

- **Syslog sources**: Add `syslog_udp` and `syslog_tcp` Vector sources bound to the non-privileged container port `1514` (UDP + TCP).
- **LoadBalancer service**: Expose only the standard syslog port `514` (UDP + TCP), mapped to target port `1514`. Pinned to a static MetalLB IP (`192.168.1.22`) so syslog senders have a stable target, consistent with the other LoadBalancer services in the cluster.
- **Metrics not exposed externally**: The Prometheus exporter port (`9090`) stays as a `containerPort` for in-cluster scraping but is intentionally **not** published on the LoadBalancer.
- **Routing**: Syslog sources are routed into the existing `vlogs` Elasticsearch bulk sink. `VL-Stream-Fields` is extended with `hostname`, `appname`, `facility`, `severity`, `source_type` so syslog metadata becomes queryable stream fields.
- **Existing collection preserved**: `customConfig` re-declares the upstream defaults (`kubernetes_logs`, `internal_metrics`, `parser`, `exporter`, `vlogs`) — setting `customConfig` replaces the chart default entirely, so this is required to keep Kubernetes log collection working, not extra configuration.

### Usage

Point syslog senders at `192.168.1.22:514` (UDP or TCP).

### Verification

Rendered with `helm template`; the LoadBalancer exposes only the syslog ports and requests `192.168.1.22`.
