### PR TITLE
telegraf: daikin-altherma-esp32 mqtt to victoria metrics

### DIFF
--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -63,6 +63,33 @@ telegraf:
             - "tibber/#"
           topic_tag: "topic"
           data_format: "json"
+      # ── Daikin Altherma ESP32 (X10A-Bridge) ──────────────────────────────
+      # Firmware daikin-altherma-esp32 publiziert zwei JSON-Topics unter
+      # <base> = "daikin-altherma-esp32" (CONFIG_DAIKIN_MQTT_BASE_TOPIC):
+      #   <base>/state     - gruppiertes Wärmepumpen-JSON, on-change (retained)
+      #   <base>/heartbeat - flache Board-/Link-Diagnose, fester 10s-Takt
+      # /status (LWT online/offline) und /crash sind kein Metrik-JSON und
+      # werden bewusst nicht abonniert (Parser würde fehlschlagen).
+      #
+      # Der json-Parser übernimmt nur numerische Felder; verschachtelte Objekte
+      # im state-Topic werden mit "_" zu flachen Feldnamen verkettet, z.B.
+      # outdoor_sensors.leaving_water_temp -> outdoor_sensors_leaving_water.
+      # Enum-/Text-/Boolean-Felder verwirft der Parser (Metrik-Store ist
+      # numerisch); Bus-/Heap-/RSSI-Zähler decken die Diagnose numerisch ab.
+      - mqtt_consumer:
+          name_override: "daikin_altherma"
+          servers: ["tcp://mosquitto:1883"]
+          topics: ["daikin-altherma-esp32/state"]
+          data_format: "json"
+          tags:
+            device: "daikin-altherma-esp32"
+      - mqtt_consumer:
+          name_override: "daikin_heartbeat"
+          servers: ["tcp://mosquitto:1883"]
+          topics: ["daikin-altherma-esp32/heartbeat"]
+          data_format: "json"
+          tags:
+            device: "daikin-altherma-esp32"
 
   args:
     - --config


### PR DESCRIPTION
## Was

Zwei `mqtt_consumer`-Inputs in `telegraf/values.yaml`, die die zwei JSON-Topics der `daikin-altherma-esp32`-Firmware aus mosquitto lesen und über die bestehende `influxdb`-Route nach VictoriaMetrics schreiben.

| Consumer | Topic | Inhalt |
|----------|-------|--------|
| `daikin_altherma` | `daikin-altherma-esp32/state` | gruppiertes Wärmepumpen-JSON (retained, on-change) |
| `daikin_heartbeat` | `daikin-altherma-esp32/heartbeat` | flache Board-/Link-Diagnose (10s-Takt) |

`/status` (LWT) und `/crash` sind bewusst nicht abonniert (kein numerisches Metrik-JSON).

## Metriken

Label `device="daikin-altherma-esp32"`. Der klassische `json`-Parser verflacht verschachteltes state-JSON mit `_`:
- `daikin_altherma_<gruppe>_<feld>` — z.B. `daikin_altherma_hydronic_temps_leaving_water_temp`
- `daikin_heartbeat_free_heap`, `_wifi_rssi`, `_uptime_s`, `_bus_rx_fails`, …

Enum-/Text-/Boolean-Felder verwirft der Parser (Metrik-Store ist numerisch); Bus-/Heap-/RSSI-Zähler decken die Diagnose numerisch ab.

## Verifiziert
- `yamllint telegraf/values.yaml` — sauber im neuen Block
- `helm template telegraf ./telegraf` — gültiges TOML inkl. `[inputs.mqtt_consumer.tags]`

## Annahmen
- Broker `tcp://mosquitto:1883` (wie die übrigen Consumer)
- Base-Topic Default `daikin-altherma-esp32` (`CONFIG_DAIKIN_MQTT_BASE_TOPIC`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)