### PR TITLE
telegraf: pin hostname so pod restarts stop forking every series

### DIFF
--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -22,7 +22,14 @@ telegraf:
       debug: false
       quiet: false
       logfile: ""
-      hostname: "$HOSTNAME"
+      # STATISCH, nicht "$HOSTNAME": das waere der Pod-Name, der sich bei
+      # jedem Restart aendert. "host" ist Teil der Serien-Identitaet, also
+      # erzeugte jeder Restart einen komplett neuen Satz Zeitreihen und
+      # liess die alten fuer immer enden -> Kardinalitaetswachstum,
+      # Serienbrueche in Grafana, rate()/increase() falsch ueber die Naht.
+      # (2026-07-23: 5 Pod-Namen in 2 Tagen, je ~276 Serien.) Ein fester
+      # Wert haelt das Label erhalten und beendet den Churn.
+      hostname: "telegraf"
       omit_hostname: false
 
     outputs:


### PR DESCRIPTION
## Problem

`hostname` was `"$HOSTNAME"` — the pod name. Since `host` is part of a series' identity in
VictoriaMetrics, **every telegraf restart started a brand-new set of time series and orphaned the
old ones for good.**

Measured on 2026-07-23 against the live store:

| | |
|---|---|
| `shelly_c_aprt_power` (1 measurement, 2 devices) | **77 series across 72 pod names** |
| series in the store | **1,015,539** |
| of which active | ~134,000 |

The rest are dead pod variants. Consequences beyond raw cardinality: series breaks in Grafana, and
`rate()` / `increase()` silently wrong across the seam where one pod's series ends and the next
begins.

## Fix

Pin `hostname` to a static value.

Chose this over `omit_hostname: true` so the `host` label keeps existing — any dashboard that
filters or groups by `host` keeps working. For MQTT-sourced metrics the label was never meaningful
anyway (it names the *collector*, not the source; `device` / `topic` already identify the source),
but removing it outright is the more disruptive change.

## Rollout note

This causes **one final series break** at rollout — `host` changes from the current pod name to
`telegraf` — and then stability. Nothing needs to be re-imported; existing history stays queryable
under the old label values.

## Verification

- `helm template telegraf ./telegraf` renders `hostname = "telegraf"`; the daikin-altherma-esp32
  MQTT inputs are unchanged in the rendered config
- `yamllint telegraf/values.yaml` — no new findings (the line-44 length error is pre-existing)

## Context

Found while auditing the daikin-altherma-esp32 data in VictoriaMetrics. Unrelated finding from the
same audit, already resolved directly against the store: a corrupt TSDB block in
`shelly_c_aprt_power` made every query spanning ≥7 days fail with HTTP 422; fixed via
`delete_series` after a snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)