### PR TITLE
feat(telegraf): read Meross MTS200 locally into VictoriaMetrics

### DIFF
--- a/telegraf/MEROSS-MTS200.md
+++ b/telegraf/MEROSS-MTS200.md
@@ -1,0 +1,207 @@
+# Meross MTS200 — lokale Abfrage über Telegraf
+
+Telegraf liest das WLAN-Thermostat **Meross MTS200** direkt im LAN aus (keine
+Meross-Cloud, kein Home Assistant dazwischen) und schreibt die Werte über den
+bestehenden `outputs.influxdb` nach VictoriaMetrics.
+
+Die Integration ist **inaktiv**, solange `meross.enabled: false` (Default) —
+gemergt ändert sie am laufenden Cluster nichts. Aktivierung: siehe unten.
+
+## Warum nicht einfach `inputs.http`?
+
+Meross-Geräte sprechen im LAN ein eigenes Protokoll: HTTP `POST` auf
+`http://<ip>/config` mit einem JSON-Umschlag aus `header` und `payload`. Der
+Header muss signiert sein:
+
+```
+sign = md5(messageId + device_key + timestamp)
+```
+
+`messageId` ist ein zufälliger 32-Zeichen-Hex-String, `timestamp` die aktuelle
+Unix-Zeit. Genau das kann `inputs.http` nicht: der Plugin schickt nur einen
+**statischen** Body, kein MD5 über einen frischen Zeitstempel. Deshalb steht ein
+knapp 200 Zeilen langer Poller (reine Python-Standardbibliothek, offizielles
+`python`-Image, Skript aus einer ConfigMap) dazwischen:
+
+```
+Telegraf inputs.http ──GET──▶ telegraf-meross-poller ──signierter POST──▶ MTS200
+     │                         (baut Header + sign)        http://<ip>/config
+     │◀──── payload (JSON) ────────────────────────────────────────────┘
+     ▼
+outputs.influxdb ──▶ vmsingle-vm:8428
+```
+
+Der Poller ist bewusst dumm: er gibt den `payload`-Teil der Geräteantwort
+unverändert zurück. Parsen, Umbenennen und Skalieren macht Telegraf
+(`templates/configmap-meross.yaml`), damit die Metrikdefinition dort liegt, wo
+im Repo auch die Modbus-Register liegen.
+
+Protokolldetails stammen aus [krahabb/meross_lan](https://github.com/krahabb/meross_lan)
+(`merossclient/protocol/message.py`, `httpclient.py`) und aus den dortigen
+Geräte-Traces (`emulator_traces/…mts200*.json.txt`, `…mts200b….csv`).
+
+## Was das Gerät liefert
+
+`GET Appliance.System.All` gibt den kompletten Zustand zurück; alles Relevante
+steckt in `digest.thermostat` (Auszug aus einem echten MTS200-Trace):
+
+```json
+{"mode": [{"channel": 0, "onoff": 1, "mode": 4, "state": 0, "currentTemp": 210,
+           "heatTemp": 200, "coolTemp": 190, "ecoTemp": 180, "manualTemp": 210,
+           "warning": 0, "targetTemp": 210, "min": 50, "max": 350,
+           "lmTime": 1674112153}],
+ "windowOpened": [{"channel": 0, "status": 0, "detect": 1, "lmTime": 1674112153}]}
+```
+
+Ein Request pro Intervall genügt also für sämtliche Werte. `Appliance.System.Runtime`
+(`{"runtime": {"signal": 100}}`) wird zusätzlich alle 5 Minuten für die
+WLAN-Signalstärke abgefragt.
+
+## Metriken in VictoriaMetrics
+
+Alle Serien tragen `device="<name aus values.yaml>"` und `channel="0"`.
+Temperaturen liefert das Gerät in **Zehntelgrad** (210 = 21,0 °C); der
+`processors.scale`-Block rechnet mit `factor = 0.1` um.
+
+| Metrik                                  | Quelle (JSON)  | Bedeutung |
+|-----------------------------------------|----------------|-----------|
+| `meross_mts200_temperature`             | `currentTemp`  | Ist-Temperatur (°C) |
+| `meross_mts200_target_temp`             | `targetTemp`   | aktueller Sollwert (°C) |
+| `meross_mts200_heat_temp`               | `heatTemp`     | Sollwert Preset *heat/comfort* (°C) |
+| `meross_mts200_cool_temp`               | `coolTemp`     | Sollwert Preset *cool/night* (°C) |
+| `meross_mts200_eco_temp`                | `ecoTemp`      | Sollwert Preset *eco/away* (°C) |
+| `meross_mts200_manual_temp`             | `manualTemp`   | Sollwert Handbetrieb (°C) |
+| `meross_mts200_onoff`                   | `onoff`        | Thermostat ein (1) / aus (0) |
+| `meross_mts200_state`                   | `state`        | Heizkreis gerade aktiv (Relais, 0/1) |
+| `meross_mts200_mode`                    | `mode`         | 0=heat, 1=cool, 2=eco, 3=auto (Zeitplan), 4=manual |
+| `meross_mts200_warning`                 | `warning`      | 0=ok, 1=Überhitzung, 2=Fühler nicht verbunden |
+| `meross_mts200_window_open`             | `windowOpened.status` | Fenster-offen erkannt (0/1) |
+| `meross_mts200_window_detection_enabled`| `windowOpened.detect` | Erkennung aktiviert (0/1) |
+| `meross_mts200_runtime_signal`          | `runtime.signal` | WLAN-Signal (%) |
+
+`lmTime` (Zeitstempel der letzten Änderung) sowie `min`/`max` (Gerätekonstanten
+5,0 / 35,0 °C) werden über `excluded_keys` verworfen — als Zeitreihe wertlos.
+
+Die Mode-Codes sind aus `meross_lan` übernommen (`climate.py`,
+`MTS200_MODE_*`); dort stehen sie unter dem Vorbehalt "inferred from a user
+trace". Vor dem Bau eines Dashboards also einmal gegen das Display prüfen.
+
+Beispiel-Queries:
+
+```promql
+meross_mts200_temperature{device="wohnzimmer"}
+meross_mts200_target_temp{device="wohnzimmer"} - meross_mts200_temperature{device="wohnzimmer"}
+avg_over_time(meross_mts200_state{device="wohnzimmer"}[1h])   # Heiz-Taktverhältnis
+```
+
+## Aktivierung
+
+1. **Geräte-IP fixieren** (DHCP-Reservierung im Router). Der MTS200 muss aus
+   dem Cluster-Netz per HTTP erreichbar sein.
+
+2. **Device-Key besorgen.** Der Key gehört zum *Meross-Account*, nicht zum
+   einzelnen Gerät — alle Geräte desselben Accounts teilen ihn. Quellen:
+   - `meross_lan` in Home Assistant einrichten (holt den Key beim Login über
+     die Meross-Cloud-API) und den Wert aus dem Config-Entry übernehmen,
+   - oder [MerossIot](https://github.com/albertogeniola/MerossIot) (`meross_api_cli`),
+   - oder `GET Appliance.Config.Key` bei einem noch nicht gekoppelten Gerät.
+
+   Test von einem Rechner im LAN (`TS` und `SIGN` frisch berechnen):
+
+   ```sh
+   MID=$(head -c16 /dev/urandom | md5sum | cut -d' ' -f1)
+   TS=$(date +%s)
+   SIGN=$(printf '%s%s%s' "$MID" "$KEY" "$TS" | md5sum | cut -d' ' -f1)
+   curl -s http://192.168.1.60/config -H 'Content-Type: application/json' -d "{
+     \"header\": {\"messageId\":\"$MID\",\"namespace\":\"Appliance.System.All\",
+                  \"method\":\"GET\",\"payloadVersion\":1,\"from\":\"MerossClient\",
+                  \"timestamp\":$TS,\"timestampMs\":0,\"sign\":\"$SIGN\"},
+     \"payload\": {}}"
+   ```
+
+   Antwortet das Gerät mit `{"error":{"code":5001,…}}`, passt der Key nicht.
+
+3. **Key versiegeln** und nach `values.yaml` eintragen:
+
+   ```sh
+   echo -n "<device-key>" | kubeseal --raw --namespace default --name telegraf-meross
+   ```
+
+4. **`telegraf/values.yaml`** anpassen:
+
+   ```yaml
+   meross:
+     enabled: true
+     devices:
+       - name: wohnzimmer
+         host: 192.168.1.60
+     sealedKey: "AgA…"
+   ```
+
+5. Mergen, ArgoCD synchronisiert. Danach laufen ein zusätzlicher Pod
+   (`telegraf-meross-poller`) und die neuen Inputs im Telegraf-Pod.
+
+## Prüfen und Debuggen
+
+```sh
+kubectl logs deploy/telegraf-meross-poller
+kubectl port-forward deploy/telegraf-meross-poller 9110:9110
+curl -s "localhost:9110/poll?host=192.168.1.60&namespace=Appliance.System.All" | jq .all.digest
+```
+
+Der Poller antwortet mit `502` und einer Klartextmeldung, wenn das Gerät nicht
+erreichbar ist oder die Signatur ablehnt; Telegraf protokolliert das dann als
+fehlgeschlagenen `inputs.http`-Scrape. Es werden in dem Fall **keine** Werte
+geschrieben — es gibt also keine eingefrorenen Messwerte, sondern eine Lücke in
+der Zeitreihe.
+
+Sicherheitsnetz im Poller: die Methode ist fest auf `GET` verdrahtet und nur
+lesende Namespaces stehen auf der Allowlist, dazu die konfigurierten Hosts.
+Über den Endpunkt lässt sich das Thermostat also nicht verstellen.
+
+## Grenzen und Fallstricke
+
+- **Verschlüsselte Firmware.** Neuere Meross-Firmware kann die lokale
+  HTTP-Kommunikation AES-verschlüsseln (Ability `Appliance.Encrypt.ECDHE`).
+  Taucht dieser Namespace in `GET Appliance.System.Ability` auf, reicht der
+  Klartext-POST nicht mehr und der Poller müsste den Handshake aus `meross_lan`
+  nachbauen. Bei den bekannten MTS200-Firmwares (7.6.x) ist das nicht der Fall,
+  obwohl `firmware.encrypt: 1` gemeldet wird.
+- **Cloud-Bindung bleibt.** Lokales Auslesen ändert nichts daran, dass das Gerät
+  weiterhin mit dem Meross-MQTT-Broker spricht. Wer das abstellt, verliert die
+  App-Steuerung.
+- **Polling, kein Push.** 30 s Intervall ist ein Kompromiss; das Gerät liefert
+  keine Änderungsmeldungen über HTTP. Kürzere Intervalle belasten das
+  WLAN-Modul des Thermostats spürbar.
+- **Ein Poller für alle Geräte.** Mehrere Thermostate werden über
+  `meross.devices` ergänzt, nicht über mehrere Deployments.
+
+## Verworfene Alternativen
+
+- **`inputs.http` mit fest einkodierter Signatur.** `messageId`, `timestamp`
+  und `sign` einmal berechnen und statisch in den Body schreiben. Das käme ganz
+  ohne Poller aus — funktioniert aber nur, falls die Firmware den Zeitstempel
+  nicht auf Aktualität prüft. Ungetestet und ein stiller Ausfall, sobald eine
+  Firmware das anzieht.
+- **MQTT-Rebind auf den Cluster-Broker.** Das Gerät lässt sich auf einen
+  eigenen Broker umbiegen (`Appliance.Config.Key` mit `server`/`port`), dann
+  würde `inputs.mqtt_consumer` wie bei Shelly/EMS-ESP reichen. Der MTS200
+  verlangt dafür aber TLS auf 8883; unser Mosquitto hört nur unverschlüsselt
+  auf 1883, und die App-Steuerung wäre weg.
+- **Umweg über Home Assistant.** `meross_lan` in HA plus Export nach
+  VictoriaMetrics. Weniger Code, aber eine zusätzliche Abhängigkeit in einem
+  Pfad, der sonst ohne HA auskommt — und die Metriken hingen an der
+  HA-Verfügbarkeit.
+
+## Dateien
+
+- `templates/configmap-meross.yaml` — `inputs.http` + `processors.rename`/
+  `processors.scale`; ConfigMap `telegraf-meross`, gemountet nach
+  `/etc/telegraf/meross.d`. Wird immer gerendert, bleibt ohne
+  `meross.enabled` aber leer.
+- `templates/configmap-meross-poller.yaml` — das Poller-Skript.
+- `templates/meross-poller-deployment.yaml`, `templates/meross-poller-service.yaml`
+  — Poller-Pod und Service `telegraf-meross-poller:9110`.
+- `templates/sealed-secret-meross.yaml` — SealedSecret `telegraf-meross`
+  (Schlüssel `device-key`), gerendert sobald `meross.sealedKey` gesetzt ist.
+- `values.yaml` — Block `meross:` plus Mount/`--config-directory`.

--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -12,3 +12,7 @@ helm install telegraf .
 ```
 helm uninstall telegraf
 ```
+
+## Integrationen
+- [Daikin Altherma (Modbus)](DAIKIN-MODBUS.md)
+- [Meross MTS200 (lokales HTTP)](MEROSS-MTS200.md)

--- a/telegraf/templates/configmap-meross-poller.yaml
+++ b/telegraf/templates/configmap-meross-poller.yaml
@@ -1,0 +1,208 @@
+{{- /*
+  Poll-Proxy für Meross-Geräte im LAN.
+
+  Grund für dieses Skript: Meross verlangt pro Anfrage einen signierten Header
+  (sign = md5(messageId + device_key + timestamp), siehe krahabb/meross_lan,
+  merossclient/protocol/message.py). Telegrafs inputs.http kann nur statische
+  Bodies senden und kein MD5 über einen frischen Zeitstempel bilden — deshalb
+  dieser kleine Übersetzer: Telegraf fragt per GET, der Poller macht daraus die
+  signierte POST-Anfrage an http://<geraet>/config und gibt den payload-Teil
+  der Antwort unverändert zurück.
+
+  Nur Python-Standardbibliothek, damit das offizielle python-Image ohne
+  eigenes Build/Registry-Image reicht.
+*/}}
+{{- if .Values.meross.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telegraf-meross-poller
+  labels:
+    app.kubernetes.io/name: telegraf-meross-poller
+data:
+  poller.py: |
+    #!/usr/bin/env python3
+    """Meross Local-LAN Poller — signierte GET-Abfragen für Telegraf.
+
+    Meross-Geräte sprechen im LAN ein simples Protokoll: HTTP POST auf
+    ``http://<ip>/config`` mit einem JSON-Umschlag aus ``header`` + ``payload``.
+    Der Header muss signiert sein:
+
+        sign = md5(messageId + device_key + timestamp)
+
+    (siehe krahabb/meross_lan, ``merossclient/protocol/message.py``). Genau diese
+    Signatur kann Telegrafs ``inputs.http`` nicht bilden — der Plugin schickt nur
+    statische Bodies. Dieser Poller ist der fehlende Baustein: er nimmt eine
+    GET-Anfrage von Telegraf entgegen, baut daraus die signierte Geräteanfrage und
+    gibt den ``payload``-Teil der Antwort 1:1 als JSON zurück. Das Parsen,
+    Umbenennen und Skalieren übernimmt Telegraf (siehe meross.conf).
+
+    Endpunkte:
+        GET /poll?host=<ip>&namespace=<ns>   Geräteantwort (payload) als JSON
+        GET /healthz                         Liveness/Readiness
+
+    Nur die Methode ``GET`` wird an das Gerät geschickt und nur Namespaces aus
+    NAMESPACES sind erlaubt — der Endpunkt kann das Thermostat also nicht
+    verstellen, nur lesen.
+
+    Konfiguration über Environment:
+        MEROSS_KEY      Device-Key (aus dem Meross-Account bzw. Appliance.Config.Key)
+        MEROSS_HOSTS    Komma-Liste erlaubter Geräte-IPs
+        MEROSS_TIMEOUT  Timeout je Geräteanfrage in Sekunden (Default 8)
+        MEROSS_PORT     Listen-Port (Default 9110)
+    """
+
+    import hashlib
+    import json
+    import os
+    import sys
+    import time
+    import urllib.error
+    import urllib.request
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from urllib.parse import parse_qs, urlparse
+
+    KEY = os.environ.get("MEROSS_KEY", "")
+    HOSTS = [h.strip() for h in os.environ.get("MEROSS_HOSTS", "").split(",") if h.strip()]
+    TIMEOUT = float(os.environ.get("MEROSS_TIMEOUT", "8"))
+    PORT = int(os.environ.get("MEROSS_PORT", "9110"))
+
+    # Lesende Namespaces des MTS200 (Ability-Liste des Geräts). Bewusst eine
+    # Allowlist: alles andere wird abgelehnt, bevor das Gerät kontaktiert wird.
+    NAMESPACES = frozenset(
+        (
+            "Appliance.System.All",
+            "Appliance.System.Runtime",
+            "Appliance.Control.Thermostat.Mode",
+            "Appliance.Control.Thermostat.Calibration",
+            "Appliance.Control.Thermostat.DeadZone",
+            "Appliance.Control.Thermostat.Frost",
+            "Appliance.Control.Thermostat.Overheat",
+            "Appliance.Control.Thermostat.WindowOpened",
+            "Appliance.Control.Thermostat.Schedule",
+            "Appliance.Control.Sensor.Latest",
+        )
+    )
+
+    # Fehlercode des Geräts bei falscher Signatur / falschem Key.
+    ERROR_INVALIDKEY = 5001
+
+
+    def log(message):
+        sys.stderr.write("%s meross-poller: %s\n" % (time.strftime("%Y-%m-%d %H:%M:%S"), message))
+        sys.stderr.flush()
+
+
+    def build_message(namespace):
+        """Signierter Meross-Umschlag für eine GET-Abfrage."""
+        message_id = hashlib.md5(os.urandom(16)).hexdigest()
+        timestamp = int(time.time())
+        signature = hashlib.md5(
+            (message_id + KEY + str(timestamp)).encode("utf-8")
+        ).hexdigest()
+        return {
+            "header": {
+                "messageId": message_id,
+                "namespace": namespace,
+                "method": "GET",
+                "payloadVersion": 1,
+                "from": "MerossClient",
+                "timestamp": timestamp,
+                "timestampMs": 0,
+                "sign": signature,
+            },
+            "payload": {},
+        }
+
+
+    def device_request(host, namespace):
+        """Fragt das Gerät ab und liefert den payload-Teil der Antwort."""
+        body = json.dumps(build_message(namespace)).encode("utf-8")
+        request = urllib.request.Request(
+            "http://%s/config" % host,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            message = json.loads(response.read().decode("utf-8"))
+
+        payload = message.get("payload")
+        if not isinstance(payload, dict):
+            raise ValueError("unerwartete Antwort ohne payload-Objekt")
+
+        error = payload.get("error")
+        if error:
+            code = error.get("code")
+            if code == ERROR_INVALIDKEY:
+                raise ValueError(
+                    "Gerät lehnt die Signatur ab (5001) — MEROSS_KEY passt nicht zum Gerät"
+                )
+            raise ValueError("Gerätefehler %s: %s" % (code, error.get("detail", "")))
+
+        return payload
+
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "meross-poller"
+
+        def log_message(self, format, *args):
+            # Erfolgreiche Scrapes alle paar Sekunden würden das Log fluten;
+            # Fehler werden in do_GET explizit geloggt.
+            pass
+
+        def _respond(self, status, document):
+            body = json.dumps(document).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            url = urlparse(self.path)
+
+            if url.path == "/healthz":
+                self._respond(200, {"status": "ok"})
+                return
+
+            if url.path != "/poll":
+                self._respond(404, {"error": "unbekannter Pfad"})
+                return
+
+            query = parse_qs(url.query)
+            namespace = query.get("namespace", ["Appliance.System.All"])[0]
+            host = query.get("host", [HOSTS[0] if HOSTS else ""])[0]
+
+            if namespace not in NAMESPACES:
+                self._respond(400, {"error": "Namespace nicht erlaubt: %s" % namespace})
+                return
+            if host not in HOSTS:
+                self._respond(400, {"error": "Host nicht in MEROSS_HOSTS: %s" % host})
+                return
+
+            try:
+                self._respond(200, device_request(host, namespace))
+            except urllib.error.URLError as error:
+                log("%s %s nicht erreichbar: %s" % (host, namespace, error.reason))
+                self._respond(502, {"error": str(error.reason)})
+            except Exception as error:  # Timeout, JSON-Murks, Gerätefehler
+                log("%s %s fehlgeschlagen: %s" % (host, namespace, error))
+                self._respond(502, {"error": str(error)})
+
+
+    def main():
+        if not HOSTS:
+            log("MEROSS_HOSTS ist leer — es wird kein Gerät abgefragt")
+        if not KEY:
+            log("MEROSS_KEY ist leer — funktioniert nur bei ungekoppelten Geräten")
+        server = ThreadingHTTPServer(("", PORT), Handler)
+        server.daemon_threads = True
+        log("hört auf :%d für %s" % (PORT, ", ".join(HOSTS) or "<keine Hosts>"))
+        server.serve_forever()
+
+
+    if __name__ == "__main__":
+        main()
+{{- end }}

--- a/telegraf/templates/configmap-meross.yaml
+++ b/telegraf/templates/configmap-meross.yaml
@@ -1,0 +1,121 @@
+{{- /*
+  Meross MTS200 (WLAN-Thermostat) — lokale Abfrage ohne Meross-Cloud.
+
+  Telegraf holt die Werte nicht direkt vom Thermostat: Meross verlangt einen
+  signierten Header (sign = md5(messageId + device_key + timestamp)), den
+  inputs.http nicht bilden kann. Dazwischen steht der Poller
+  (templates/meross-poller-deployment.yaml), der die Signatur baut und die
+  Geräteantwort unverändert als JSON ausliefert. Hier wird nur geparst,
+  umbenannt und skaliert.
+
+  Die ConfigMap wird IMMER gerendert (values.yaml mountet sie unbedingt nach
+  /etc/telegraf/meross.d); ohne `meross.enabled` bleibt sie leer, das
+  --config-directory ist dann schlicht ohne Inhalt.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telegraf-meross
+  labels:
+    app.kubernetes.io/name: telegraf
+{{- if and .Values.meross.enabled .Values.meross.devices }}
+data:
+  meross.conf: |
+{{- range .Values.meross.devices }}
+    # ── {{ .name }} ({{ .host }}) ────────────────────────────────────────
+    # Appliance.System.All liefert den kompletten Gerätezustand inklusive
+    # digest.thermostat — ein Request pro Intervall reicht für alle Werte.
+    [[inputs.http]]
+      urls = ["http://telegraf-meross-poller:9110/poll?host={{ .host }}&namespace=Appliance.System.All"]
+      method = "GET"
+      interval = "{{ $.Values.meross.interval }}"
+      timeout = "15s"
+      data_format = "json_v2"
+      [inputs.http.tags]
+        device = "{{ .name }}"
+      # digest.thermostat.mode ist ein Array (ein Element je Kanal); json_v2
+      # macht daraus je eine Zeile, `channel` wird zum Tag.
+      #   onoff  0/1  Thermostat ein/aus
+      #   mode   0=heat 1=cool 2=eco 3=auto(Zeitplan) 4=manual
+      #   state  0/1  Heizkreis gerade aktiv (Relais)
+      #   warning 0=ok 1=Überhitzung 2=Fühler nicht verbunden
+      # lmTime/min/max sind Konstanten bzw. ein Änderungszeitstempel —
+      # als Zeitreihe wertlos, deshalb ausgeschlossen.
+      [[inputs.http.json_v2]]
+        measurement_name = "meross_mts200"
+        [[inputs.http.json_v2.object]]
+          path = "all.digest.thermostat.mode"
+          disable_prepend_keys = true
+          tags = ["channel"]
+          excluded_keys = ["lmTime", "min", "max"]
+      # Fenster-offen-Erkennung: status = erkannt, detect = Funktion aktiv.
+      [[inputs.http.json_v2]]
+        measurement_name = "meross_mts200_window"
+        [[inputs.http.json_v2.object]]
+          path = "all.digest.thermostat.windowOpened"
+          disable_prepend_keys = true
+          tags = ["channel"]
+          excluded_keys = ["lmTime"]
+
+    # WLAN-Signalstärke (%). Eigener Namespace, eigener Request — deshalb
+    # bewusst seltener als der Gerätezustand.
+    [[inputs.http]]
+      urls = ["http://telegraf-meross-poller:9110/poll?host={{ .host }}&namespace=Appliance.System.Runtime"]
+      method = "GET"
+      interval = "5m"
+      timeout = "15s"
+      data_format = "json_v2"
+      [inputs.http.tags]
+        device = "{{ .name }}"
+      [[inputs.http.json_v2]]
+        measurement_name = "meross_mts200_runtime"
+        [[inputs.http.json_v2.object]]
+          path = "runtime"
+          disable_prepend_keys = true
+{{- end }}
+
+    # ── Aufbereitung ─────────────────────────────────────────────────────
+    # Prozessoren greifen global, deshalb überall namepass. `order` fixiert
+    # die Reihenfolge: erst umbenennen (1), dann skalieren (2) — die scale-
+    # Filter unten arbeiten bereits mit den neuen Feldnamen.
+    [[processors.rename]]
+      order = 1
+      namepass = ["meross_mts200"]
+      [[processors.rename.replace]]
+        field = "currentTemp"
+        dest = "temperature"
+      [[processors.rename.replace]]
+        field = "targetTemp"
+        dest = "target_temp"
+      [[processors.rename.replace]]
+        field = "heatTemp"
+        dest = "heat_temp"
+      [[processors.rename.replace]]
+        field = "coolTemp"
+        dest = "cool_temp"
+      [[processors.rename.replace]]
+        field = "ecoTemp"
+        dest = "eco_temp"
+      [[processors.rename.replace]]
+        field = "manualTemp"
+        dest = "manual_temp"
+
+    [[processors.rename]]
+      order = 1
+      namepass = ["meross_mts200_window"]
+      [[processors.rename.replace]]
+        field = "status"
+        dest = "open"
+      [[processors.rename.replace]]
+        field = "detect"
+        dest = "detection_enabled"
+
+    # Alle Temperaturen kommen in Zehntelgrad (210 = 21,0 °C).
+    [[processors.scale]]
+      order = 2
+      namepass = ["meross_mts200"]
+      [[processors.scale.scaling]]
+        factor = 0.1
+        offset = 0.0
+        fields = ["temperature", "target_temp", "heat_temp", "cool_temp", "eco_temp", "manual_temp"]
+{{- end }}

--- a/telegraf/templates/meross-poller-deployment.yaml
+++ b/telegraf/templates/meross-poller-deployment.yaml
@@ -1,0 +1,82 @@
+{{- /*
+  Poller für die lokalen Meross-Geräte (siehe configmap-meross-poller.yaml).
+
+  Eigenes Deployment statt Sidecar: der Telegraf-Chart bietet keinen Haken für
+  zusätzliche Container, und ein separater Pod lässt sich unabhängig neu
+  starten und einzeln per curl testen.
+
+  Das offizielle python-Image wird unverändert benutzt, das Skript kommt aus
+  der ConfigMap — kein eigenes Image, kein Registry-Betrieb.
+*/}}
+{{- if .Values.meross.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telegraf-meross-poller
+  labels:
+    app.kubernetes.io/name: telegraf-meross-poller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: telegraf-meross-poller
+  template:
+    metadata:
+      labels:
+        app: telegraf-meross-poller
+      annotations:
+        checksum/script: {{ include (print $.Template.BasePath "/configmap-meross-poller.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: poller
+          image: "{{ .Values.meross.image.repository }}:{{ .Values.meross.image.tag }}"
+          command: ["python3", "-u", "/opt/meross/poller.py"]
+          env:
+            # Der Device-Key ist bei einem cloud-gekoppelten Gerät Pflicht;
+            # optional: true lässt ein nie gekoppeltes Gerät (leerer Key)
+            # auch ohne SealedSecret laufen.
+            - name: MEROSS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: telegraf-meross
+                  key: device-key
+                  optional: true
+            - name: MEROSS_HOSTS
+              value: "{{- range $index, $device := .Values.meross.devices }}{{ if $index }},{{ end }}{{ $device.host }}{{- end }}"
+          ports:
+            - name: http
+              containerPort: 9110
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 60
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 96Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: script
+              mountPath: /opt/meross
+      volumes:
+        - name: script
+          configMap:
+            name: telegraf-meross-poller
+            defaultMode: 0444
+{{- end }}

--- a/telegraf/templates/meross-poller-service.yaml
+++ b/telegraf/templates/meross-poller-service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.meross.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: telegraf-meross-poller
+  labels:
+    app.kubernetes.io/name: telegraf-meross-poller
+spec:
+  selector:
+    app: telegraf-meross-poller
+  ports:
+    - name: http
+      port: 9110
+      targetPort: http
+{{- end }}

--- a/telegraf/templates/sealed-secret-meross.yaml
+++ b/telegraf/templates/sealed-secret-meross.yaml
@@ -1,0 +1,22 @@
+{{- /*
+  Meross-Device-Key. Der Key gehört zum Meross-Account, nicht zum einzelnen
+  Gerät — alle Geräte desselben Accounts teilen ihn. Erzeugen:
+
+    echo -n "<device-key>" | kubeseal --raw --namespace default --name telegraf-meross
+
+  Der Ausgabestring kommt nach values.yaml unter `meross.sealedKey`.
+*/}}
+{{- if .Values.meross.sealedKey }}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: telegraf-meross
+  namespace: default
+spec:
+  encryptedData:
+    device-key: {{ .Values.meross.sealedKey | quote }}
+  template:
+    metadata:
+      name: telegraf-meross
+      namespace: default
+{{- end }}

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -6,6 +6,24 @@
 daikin:
   enabled: true
 
+# Meross MTS200 (WLAN-Thermostat) — INAKTIV, lokal per HTTP, ohne Meross-Cloud.
+# Aktivierung (Geräte-IP, Device-Key, enabled): telegraf/MEROSS-MTS200.md.
+# Solange enabled: false bleibt, rendert nur eine leere ConfigMap
+# `telegraf-meross` — der Mount unten läuft ins Leere, sonst passiert nichts.
+meross:
+  enabled: false
+  # Ein Poller bedient alle Geräte; `name` wird zum Tag `device`.
+  devices: []
+  #  - name: wohnzimmer
+  #    host: 192.168.1.60
+  interval: "30s"
+  # Device-Key, mit kubeseal verschlüsselt (siehe MEROSS-MTS200.md).
+  sealedKey: ""
+  # Poller-Image: offizielles python-Image, das Skript kommt aus der ConfigMap.
+  image:
+    repository: python
+    tag: 3.13-alpine@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0
+
 telegraf:
   service:
     enabled: false
@@ -122,6 +140,9 @@ telegraf:
     # Daikin Home Hub EKRHH Modbus input:
     - --config-directory
     - /etc/telegraf/daikin.d
+    # Meross MTS200 HTTP input (leer solange meross.enabled: false):
+    - --config-directory
+    - /etc/telegraf/meross.d
 
   volumes:
     - name: telegraf-modbus
@@ -130,9 +151,14 @@ telegraf:
     - name: telegraf-modbus-daikin
       configMap:
         name: telegraf-modbus-daikin
+    - name: telegraf-meross
+      configMap:
+        name: telegraf-meross
 
   mountPoints:
     - name: telegraf-modbus
       mountPath: /etc/telegraf/conf.d
     - name: telegraf-modbus-daikin
       mountPath: /etc/telegraf/daikin.d
+    - name: telegraf-meross
+      mountPath: /etc/telegraf/meross.d


### PR DESCRIPTION
Liest das WLAN-Thermostat **Meross MTS200** lokal aus (keine Meross-Cloud, kein Home Assistant dazwischen) und schreibt die Werte über den bestehenden `outputs.influxdb` nach VictoriaMetrics.

## Warum ein Poller dazwischen steht

Meross verlangt pro Anfrage einen signierten Header — `sign = md5(messageId + device_key + timestamp)` — an `POST http://192.168.1.60/config`. Genau das kann `inputs.http` nicht: der Plugin sendet nur statische Bodies, kein MD5 über einen frischen Zeitstempel. Deshalb:

```
Telegraf inputs.http ──GET──▶ telegraf-meross-poller ──signierter POST──▶ MTS200
     │◀──── payload (JSON) ────────────────────────────────────────────┘
     ▼
outputs.influxdb ──▶ vmsingle-vm:8428
```

Der Poller ist ~185 Zeilen reine Python-Standardbibliothek im offiziellen `python`-Image, das Skript kommt aus einer ConfigMap — kein eigenes Image, keine Registry. Er gibt den `payload` unverändert zurück; Parsen, Umbenennen und Skalieren macht Telegraf, damit die Metrikdefinition dort liegt, wo auch die Modbus-Register liegen.

## Metriken

`GET Appliance.System.All` liefert `digest.thermostat` komplett, ein Request pro Intervall (30 s) reicht: `temperature`, `target_temp`, `heat_temp`, `cool_temp`, `eco_temp`, `manual_temp`, `onoff`, `state`, `mode`, `warning` sowie `meross_mts200_window_open` / `meross_mts200_window_detection_enabled`. `Appliance.System.Runtime` ergänzt alle 5 Minuten `meross_mts200_runtime_signal`. Temperaturen kommen in Zehntelgrad → `processors.scale` mit `factor = 0.1`; `lmTime`/`min`/`max` werden verworfen. Tags: `device` (Name aus `values.yaml`) und `channel`.

## Inaktiv bis zur Aktivierung

`meross.enabled: false` (Default) → es rendert nur eine leere ConfigMap `telegraf-meross`; das `--config-directory /etc/telegraf/meross.d` läuft ins Leere, sonst passiert nichts. Aktivierung (Geräte-IP, Device-Key per `kubeseal`, `enabled: true`) ist in `telegraf/MEROSS-MTS200.md` beschrieben, inklusive der verworfenen Alternativen (statisch signierter `inputs.http`, MQTT-Rebind auf Mosquitto, Umweg über Home Assistant) und der Grenzen (verschlüsselte Firmware `Appliance.Encrypt.ECDHE`).

## Änderungen

- `templates/configmap-meross.yaml` — `inputs.http` + `processors.rename`/`processors.scale`, immer gerendert, ohne Flag leer
- `templates/configmap-meross-poller.yaml` — Poller-Skript
- `templates/meross-poller-deployment.yaml`, `templates/meross-poller-service.yaml` — Pod + Service `telegraf-meross-poller:9110`
- `templates/sealed-secret-meross.yaml` — SealedSecret `telegraf-meross` (`device-key`, optional gemountet)
- `values.yaml` — Block `meross:`, Mount und `--config-directory`
- `MEROSS-MTS200.md`, Verweis in `README.md`

## Getestet

Der Poller wurde gegen einen Fake-MTS200 geprüft, der die Signatur genauso validiert wie das Gerät (Payload aus einem echten MTS200-Trace): korrekte Antwort für `Appliance.System.All` und `Appliance.System.Runtime`, `502` bei falschem Key (Gerätefehler 5001) und bei nicht erreichbarem Host, `400` für Host/Namespace außerhalb der Allowlist. Die gerenderte `meross.conf` wurde als TOML geparst, alle Templates als YAML. Am echten Gerät ist noch nichts getestet — Geräte-IP und Device-Key fehlen, deshalb Draft.

Protokolldetails aus [krahabb/meross_lan](https://github.com/krahabb/meross_lan) (`merossclient/protocol/message.py`, `httpclient.py`) und dessen MTS200-Traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDGXeoWfZJcWL6rBWsAzQX