### PR TITLE
perf(telegraf): tier Daikin Modbus polling

### DIFF
--- a/telegraf/DAIKIN-MODBUS.md
+++ b/telegraf/DAIKIN-MODBUS.md
@@ -4,9 +4,9 @@ Telegraf Modbus input for the heat pump (Daikin Altherma 3 R: ERGA04-08E /
 ETBH12E / EKHWSP, Home Hub **EKRHH**). The registers are **mapped** from the
 EKRHH installer reference guide `4P744838-1E`, section *"9.2 Modbus registers"*.
 
-The input stays **inactive** while `daikin.enabled: false` (default) — merging
-changes nothing in the running cluster. It is enabled once the heat pump is
-installed and the connection to the Home Hub is verified.
+The input is active for the Home Hub at `192.168.1.131:502` (`slave_id = 1`).
+All documented registers remain available, but Telegraf polls them in priority
+classes instead of reading the complete map every 30 seconds.
 
 Related analysis project: `~/Projects/waermepumpe-vs-gas/`
 (`analyse/vergleich_run.py`).
@@ -17,9 +17,8 @@ Related analysis project: `~/Projects/waermepumpe-vs-gas/`
   `daikin.conf`. Registers mapped from the EKRHH docs, gated by
   `{{ if .Values.daikin.enabled }}`. `measurement = "daikin"` → metrics land in
   VictoriaMetrics as `daikin_<field>`.
-- `values.yaml` — `daikin.enabled: false` plus commented-out activation blocks
-  (env `DAIKIN_MODBUS_CONTROLLER`, `--config-directory /etc/telegraf/daikin.d`,
-  volume, mountPoint).
+- `values.yaml` — `daikin.enabled: true`, controller environment variable,
+  config directory, volume and mount point.
 
 ## Addressing & data formats (EKRHH doc §9.2)
 
@@ -49,7 +48,24 @@ Related analysis project: `~/Projects/waermepumpe-vs-gas/`
 ## Mapped metrics
 
 **All 36 input registers (§9.2.2) and all 23 holding registers (§9.2.1) are
-read** — 59 fields total, in 8 request blocks.
+read** — 59 fields total, distributed over five poll classes and 12 request
+definitions. Metric and field names are unchanged.
+
+### Polling priorities
+
+| Priority | Interval | Register groups | Rationale |
+|----------|----------|-----------------|-----------|
+| P0 alarm | 10 s | input offsets 21–23 | Faults and warnings must become visible quickly. |
+| P1 process / ML | 30 s | input offsets 30–53; holding offsets 53–58 | Dynamic operating state, temperatures, flow, power, heating-curve mode/offsets and limits. |
+| P2 operator state | 60 s | holding offsets 1–4, 9–10, 12–13 | User-facing setpoints and switches change occasionally. |
+| P3 active configuration | 5 min | input offsets 54–57, 76–77 | Installed main-zone limits and tank sensors normally stay constant. |
+| P4 inventory / optional features | 1 h | remaining Add-zone, room-limit and thermostat registers | Preserve the complete manufacturer map without continuously polling unused features. |
+
+Each `[[inputs.modbus]]` instance has `collection_jitter` so the classes do not
+all hit the Home Hub at the same instant. Every request explicitly uses
+`optimization = "none"`: Telegraf reads only the listed addresses and does not
+fill address gaps with undocumented registers. The integration remains strictly
+read-only, including all holding registers.
 
 Input registers (`daikin_*`):
 
@@ -98,16 +114,14 @@ The only power/energy-related signal is the instantaneous **`power_consumption`*
 - `analyse/vergleich_run.py` must be aligned to the real field names above; the
   `daikin_energy_input` / `daikin_heat_output` inputs it expects have no source.
 
-## Activation (after commissioning)
+## Configuration
 
-1. **Set the controller.** In `values.yaml` uncomment `DAIKIN_MODBUS_CONTROLLER`
-   and point it at the Home Hub — Modbus **TCP** `tcp://<home-hub-ip>:502`
-   (port 802 for TLS) or **RTU/RS485** `file:///dev/ttyUSB0` (9600 8N1, then
-   uncomment the serial params in `daikin.conf`). Confirm the `slave_id`
-   (default `1`, set in the ONECTA app).
-2. **Uncomment in `values.yaml`:** the env var, `--config-directory
-   /etc/telegraf/daikin.d`, the volume and the mountPoint.
-3. **Set `daikin.enabled: true`.**
+The production values currently select Modbus TCP
+`tcp://192.168.1.131:502`; `slave_id = 1` is set in every request. To disable
+the integration, set `daikin.enabled: false`. For another Home Hub, change only
+`DAIKIN_MODBUS_CONTROLLER`. Port 802 is reserved for TLS; RTU/RS485 uses a
+`file:///dev/ttyUSB0` controller and the serial parameters documented in the
+ConfigMap.
 
 ## Testing
 
@@ -119,7 +133,7 @@ The `[[inputs.modbus]]` path is already proven in production (FoxESS →
    helm template telegraf ./telegraf --set daikin.enabled=true \
      -s templates/configmap-daikin.yaml
    ```
-2. **Dry run against the unit** (before writing to VM): temporarily enable the
+2. **Dry run against the unit** (without writing to VM): temporarily enable the
    `file` output (stdout) with `namepass = ["daikin"]` and `config.agent.debug: true`,
    then:
    ```bash
@@ -134,10 +148,10 @@ The `[[inputs.modbus]]` path is already proven in production (FoxESS →
      "curl -s 'http://vmsingle-vm:8428/api/v1/query' --data-urlencode 'query=daikin_power_consumption' -G"
    ```
 
-## Afterwards
+## Follow-up consumers
 
 - Align the metric names in `waermepumpe-vs-gas/analyse/vergleich_run.py` with
   the real fields above (and drop the unavailable energy/COP inputs, or feed them
   from the external meters).
-- Create a Grafana dashboard "Wärmepumpe" analogous to `ems-esp-heizung`.
-- Merge `daikin.enabled: true` to main → ArgoCD deploys the input.
+- Keep dashboards and ML feature queries tolerant of the slower P2–P4 cadence;
+  P1 remains the authoritative 30-second process stream.

--- a/telegraf/templates/configmap-daikin.yaml
+++ b/telegraf/templates/configmap-daikin.yaml
@@ -1,11 +1,11 @@
 {{- /*
   Daikin Altherma 3 R (Home Hub EKRHH) Modbus input for Telegraf.
 
-  Renders ONLY when `daikin.enabled: true` is set (default: false), so merging
-  this stays inert until the heat pump is installed and the connection is
-  verified. Every register documented in the EKRHH installer reference guide
-  (4P744838-1E), "9.2 Modbus registers", is read: all 36 input registers
-  (§9.2.2) and all 23 holding registers (§9.2.1).
+  Renders only when `daikin.enabled: true` is set. Every register documented
+  in the EKRHH installer reference guide (4P744838-1E), "9.2 Modbus registers",
+  remains available: all 36 input registers (§9.2.2) and all 23 holding
+  registers (§9.2.1). Poll intervals are tiered by safety relevance and the
+  observed change rate instead of reading the complete map every 30 seconds.
 
   Register addressing (doc 9.2): the data model offset is 1-based, the Modbus
   PDU address is 0-based -> address = offset - 1. Telegraf sends the PDU
@@ -43,13 +43,16 @@ data:
     # four-character byte order -> "ABCD" for big-endian (CD is unused here).
     # measurement = "daikin" => metrics arrive in VictoriaMetrics as daikin_<field>.
     # =====================================================================
+    # P0 — alarm registers: rare changes, but a fault must be visible quickly.
     [[inputs.modbus]]
+      alias = "daikin_alarm"
       name = "daikin"
       # Modbus TCP:  tcp://<home-hub-ip>:502   (port 502 plain / 802 TLS, doc §9.1)
       # Modbus RTU:  file:///dev/ttyUSB0       (RS-485, 9600 8N1, doc §9.1)
       controller = "${DAIKIN_MODBUS_CONTROLLER}"
       configuration_type = "request"
-      interval = "30s"
+      interval = "10s"
+      collection_jitter = "1s"
       timeout = "5s"
       busy_retries = 3
       busy_retries_wait = "500ms"
@@ -68,10 +71,36 @@ data:
         byte_order = "ABCD"
         register = "input"
         measurement = "daikin"
+        optimization = "none"        # Never fill gaps with undocumented registers.
         fields = [
           {name = "abnormality",       address = 20, type = "INT16",  scale = 1.0},  # off 21: 0 none/1 fault/2 warning
           {name = "abnormality_code",  address = 21, type = "UINT16", scale = 1.0},  # off 22: Text16, 2 ASCII bytes
-          {name = "abnormality_sub",   address = 22, type = "INT16",  scale = 1.0},  # off 23: 32766 none else 0..99
+          {name = "abnormality_sub",   address = 22, type = "INT16",  scale = 1.0}   # off 23: 32766 none else 0..99
+        ]
+
+    # P1 — process and ML features. These are the dynamic signals used to
+    # reconstruct operation and later evaluate/adapt the heating curve.
+    [[inputs.modbus]]
+      alias = "daikin_process"
+      name = "daikin"
+      controller = "${DAIKIN_MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "30s"
+      collection_jitter = "3s"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      [inputs.modbus.tags]
+        device = "daikin_altherma_3r"
+
+      # ── Input registers: unit status & operation (read-only, doc §9.2.2) ──
+      [[inputs.modbus.request]]
+        slave_id = 1
+        byte_order = "ABCD"
+        register = "input"
+        measurement = "daikin"
+        optimization = "none"
+        fields = [
           {name = "circulation_pump",  address = 29, type = "INT16",  scale = 1.0},  # off 30: 0/1
           {name = "compressor",        address = 30, type = "INT16",  scale = 1.0},  # off 31: 0/1
           {name = "booster_heater",    address = 31, type = "INT16",  scale = 1.0},  # off 32: 0/1
@@ -88,6 +117,7 @@ data:
         byte_order = "ABCD"
         register = "input"
         measurement = "daikin"
+        optimization = "none"
         fields = [
           {name = "leaving_water_phe", address = 39, type = "INT16", scale = 0.01},  # off 40: Temp16 °C (heat pump PHE)
           {name = "leaving_water_buh", address = 40, type = "INT16", scale = 0.01},  # off 41: Temp16 °C (after backup heater = flow temp)
@@ -102,22 +132,50 @@ data:
           {name = "space_operation",   address = 52, type = "INT16", scale = 1.0}    # off 53: 0 idle/1 operating
         ]
 
-      # ── Input registers: leaving-water setpoint limits, Main + Add (doc §9.2.2) ──
-      # Temp16 field-setting ranges; Add-zone entries read 32766 on single-zone systems.
+      # ── Holding registers: heating curve, smart grid and power limits ─────
+      # These values explain why the plant selected a particular operating
+      # point. Telegraf remains strictly read-only.
+      [[inputs.modbus.request]]
+        slave_id = 1
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "daikin"
+        optimization = "none"
+        fields = [
+          {name = "set_wd_mode_main",        address = 52, type = "INT16", scale = 1.0},   # off 53: 0 fixed/1 WD/2 fixed+sched/3 WD+sched
+          {name = "set_wd_heat_offset_main", address = 53, type = "INT16", scale = 1.0},   # off 54: -10..10 °C
+          {name = "set_wd_cool_offset_main", address = 54, type = "INT16", scale = 1.0},   # off 55: -10..10 °C
+          {name = "set_smart_grid_mode",     address = 55, type = "INT16", scale = 1.0},   # off 56: 0 free/1 forced off/2 recommended on/3 forced on
+          {name = "set_power_limit_buffer",  address = 56, type = "INT16", scale = 0.01},  # off 57: Pow16 kW 0..20
+          {name = "set_general_power_limit", address = 57, type = "INT16", scale = 0.01}   # off 58: Pow16 kW 0..20
+        ]
+
+    # P3 — active configuration: useful for validation, but normally static.
+    [[inputs.modbus]]
+      alias = "daikin_configuration"
+      name = "daikin"
+      controller = "${DAIKIN_MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "5m"
+      collection_jitter = "30s"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      [inputs.modbus.tags]
+        device = "daikin_altherma_3r"
+
+      # ── Input registers: Main leaving-water setpoint limits (doc §9.2.2) ──
       [[inputs.modbus.request]]
         slave_id = 1
         byte_order = "ABCD"
         register = "input"
         measurement = "daikin"
+        optimization = "none"
         fields = [
           {name = "limit_lwt_heat_main_lower", address = 53, type = "INT16", scale = 0.01},  # off 54: °C
           {name = "limit_lwt_heat_main_upper", address = 54, type = "INT16", scale = 0.01},  # off 55: °C
           {name = "limit_lwt_cool_main_lower", address = 55, type = "INT16", scale = 0.01},  # off 56: °C
-          {name = "limit_lwt_cool_main_upper", address = 56, type = "INT16", scale = 0.01},  # off 57: °C
-          {name = "limit_lwt_heat_add_lower",  address = 57, type = "INT16", scale = 0.01},  # off 58: °C (Add zone)
-          {name = "limit_lwt_heat_add_upper",  address = 58, type = "INT16", scale = 0.01},  # off 59: °C (Add zone)
-          {name = "limit_lwt_cool_add_lower",  address = 59, type = "INT16", scale = 0.01},  # off 60: °C (Add zone)
-          {name = "limit_lwt_cool_add_upper",  address = 60, type = "INT16", scale = 0.01}   # off 61: °C (Add zone)
+          {name = "limit_lwt_cool_main_upper", address = 56, type = "INT16", scale = 0.01}   # off 57: °C
         ]
 
       # ── Input registers: DHW tank top/bottom temperatures (EKHWSP), doc §9.2.2 ──
@@ -126,17 +184,48 @@ data:
         byte_order = "ABCD"
         register = "input"
         measurement = "daikin"
+        optimization = "none"
         fields = [
           {name = "dhw_upper", address = 75, type = "INT16", scale = 0.01},  # off 76: Temp16 °C (tank upper)
           {name = "dhw_lower", address = 76, type = "INT16", scale = 0.01}   # off 77: Temp16 °C (tank lower)
         ]
 
-      # ── Input registers: room setpoint limits (doc §9.2.2) ──────────────────
+    # P4 — inventory and currently unavailable options. Keep the complete
+    # manufacturer map observable without continuously polling unused features.
+    [[inputs.modbus]]
+      alias = "daikin_inventory"
+      name = "daikin"
+      controller = "${DAIKIN_MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "1h"
+      collection_jitter = "5m"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      [inputs.modbus.tags]
+        device = "daikin_altherma_3r"
+
+      # ── Input registers: Add-zone leaving-water limits ───────────────────
       [[inputs.modbus.request]]
         slave_id = 1
         byte_order = "ABCD"
         register = "input"
         measurement = "daikin"
+        optimization = "none"
+        fields = [
+          {name = "limit_lwt_heat_add_lower", address = 57, type = "INT16", scale = 0.01},  # off 58: °C
+          {name = "limit_lwt_heat_add_upper", address = 58, type = "INT16", scale = 0.01},  # off 59: °C
+          {name = "limit_lwt_cool_add_lower", address = 59, type = "INT16", scale = 0.01},  # off 60: °C
+          {name = "limit_lwt_cool_add_upper", address = 60, type = "INT16", scale = 0.01}   # off 61: °C
+        ]
+
+      # ── Input registers: room setpoint limits (doc §9.2.2) ───────────────
+      [[inputs.modbus.request]]
+        slave_id = 1
+        byte_order = "ABCD"
+        register = "input"
+        measurement = "daikin"
+        optimization = "none"
         fields = [
           {name = "limit_room_heat_lower", address = 83, type = "INT16", scale = 0.01},  # off 84: °C
           {name = "limit_room_heat_upper", address = 84, type = "INT16", scale = 0.01},  # off 85: °C
@@ -144,60 +233,75 @@ data:
           {name = "limit_room_cool_upper", address = 86, type = "INT16", scale = 0.01}   # off 87: °C
         ]
 
-      # ── Holding registers: main setpoints & control state (R/W, doc §9.2.1) ──
-      # Read here for monitoring only; Telegraf never writes.
+      # ── Holding registers: unavailable room-control setpoints ────────────
       [[inputs.modbus.request]]
         slave_id = 1
         byte_order = "ABCD"
         register = "holding"
         measurement = "daikin"
+        optimization = "none"
         fields = [
-          {name = "set_lwt_heating_main",  address = 0,  type = "INT16", scale = 1.0},  # off 1:  °C (field-setting range)
-          {name = "set_lwt_cooling_main",  address = 1,  type = "INT16", scale = 1.0},  # off 2:  °C (field-setting range)
-          {name = "set_operation_mode",    address = 2,  type = "INT16", scale = 1.0},  # off 3:  0 auto/1 heat/2 cool (32766 heating-only)
-          {name = "set_space_onoff",       address = 3,  type = "INT16", scale = 1.0},  # off 4:  0/1
-          {name = "set_room_heating_main", address = 5,  type = "INT16", scale = 1.0},  # off 6:  12..30 °C
-          {name = "set_room_cooling_main", address = 6,  type = "INT16", scale = 1.0},  # off 7:  15..35 °C
-          {name = "set_quiet_mode",        address = 8,  type = "INT16", scale = 1.0},  # off 9:  0/1
+          {name = "set_room_heating_main", address = 5, type = "INT16", scale = 1.0},  # off 6: 12..30 °C
+          {name = "set_room_cooling_main", address = 6, type = "INT16", scale = 1.0}   # off 7: 15..35 °C
+        ]
+
+      # ── Holding registers: external thermostat inputs ────────────────────
+      [[inputs.modbus.request]]
+        slave_id = 1
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "daikin"
+        optimization = "none"
+        fields = [
+          {name = "thermostat_main_input", address = 58, type = "INT16", scale = 1.0},  # off 59: model-dependent
+          {name = "thermostat_add_input",  address = 60, type = "INT16", scale = 1.0}   # off 61: model-dependent
+        ]
+
+      # ── Holding registers: additional (Add) zone setpoints & WD mode ─────
+      [[inputs.modbus.request]]
+        slave_id = 1
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "daikin"
+        optimization = "none"
+        fields = [
+          {name = "set_lwt_heating_add",    address = 62, type = "INT16", scale = 1.0},  # off 63: °C
+          {name = "set_lwt_cooling_add",    address = 63, type = "INT16", scale = 1.0},  # off 64: °C
+          {name = "set_wd_mode_add",        address = 64, type = "INT16", scale = 1.0},  # off 65: 0..3
+          {name = "set_wd_heat_offset_add", address = 65, type = "INT16", scale = 1.0},  # off 66: -10..10 °C
+          {name = "set_wd_cool_offset_add", address = 66, type = "INT16", scale = 1.0}   # off 67: -10..10 °C
+        ]
+
+    # P2 — operator-controlled state and primary setpoints.
+    [[inputs.modbus]]
+      alias = "daikin_operator"
+      name = "daikin"
+      controller = "${DAIKIN_MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "60s"
+      collection_jitter = "10s"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      [inputs.modbus.tags]
+        device = "daikin_altherma_3r"
+
+      # ── Holding registers: main setpoints & control state ────────────────
+      # Telegraf only reads these R/W registers; it never writes.
+      [[inputs.modbus.request]]
+        slave_id = 1
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "daikin"
+        optimization = "none"
+        fields = [
+          {name = "set_lwt_heating_main",  address = 0,  type = "INT16", scale = 1.0},  # off 1: °C
+          {name = "set_lwt_cooling_main",  address = 1,  type = "INT16", scale = 1.0},  # off 2: °C
+          {name = "set_operation_mode",    address = 2,  type = "INT16", scale = 1.0},  # off 3: 0 auto/1 heat/2 cool
+          {name = "set_space_onoff",       address = 3,  type = "INT16", scale = 1.0},  # off 4: 0/1
+          {name = "set_quiet_mode",        address = 8,  type = "INT16", scale = 1.0},  # off 9: 0/1
           {name = "set_dhw_reheat",        address = 9,  type = "INT16", scale = 1.0},  # off 10: 30..60 °C
           {name = "set_dhw_reheat_onoff",  address = 11, type = "INT16", scale = 1.0},  # off 12: 0/1
-          {name = "set_dhw_booster_onoff", address = 12, type = "INT16", scale = 1.0}   # off 13: 0/1 (powerful)
-        ]
-
-      # ── Holding registers: weather-dependent, smart grid, power limits,
-      #    external thermostat inputs (R/W, doc §9.2.1) ──
-      # Thermostat inputs (off 59/61) are documented as NOT operational on
-      # Altherma 3 R indoor units (Micon ID 20002203) and only valid with
-      # external SW-contact thermostat control ([C-07]=1, [C-05]=0) — read for
-      # completeness; expect 0.
-      [[inputs.modbus.request]]
-        slave_id = 1
-        byte_order = "ABCD"
-        register = "holding"
-        measurement = "daikin"
-        fields = [
-          {name = "set_wd_mode_main",       address = 52, type = "INT16", scale = 1.0},   # off 53: 0 fixed/1 WD/2 fixed+sched/3 WD+sched
-          {name = "set_wd_heat_offset_main",address = 53, type = "INT16", scale = 1.0},   # off 54: -10..10 °C
-          {name = "set_wd_cool_offset_main",address = 54, type = "INT16", scale = 1.0},   # off 55: -10..10 °C
-          {name = "set_smart_grid_mode",    address = 55, type = "INT16", scale = 1.0},   # off 56: 0 free/1 forced off/2 recommended on/3 forced on
-          {name = "set_power_limit_buffer", address = 56, type = "INT16", scale = 0.01},  # off 57: Pow16 kW 0..20 (recommended-on / buffering)
-          {name = "set_general_power_limit",address = 57, type = "INT16", scale = 0.01},  # off 58: Pow16 kW 0..20
-          {name = "thermostat_main_input",  address = 58, type = "INT16", scale = 1.0},   # off 59: 0/1 (not operational on Altherma 3 R)
-          {name = "thermostat_add_input",   address = 60, type = "INT16", scale = 1.0}    # off 61: 0/1 (not operational on Altherma 3 R)
-        ]
-
-      # ── Holding registers: additional (Add) zone setpoints & WD mode (doc §9.2.1) ──
-      # Present only on 2-zone systems; single-zone installs return 32766.
-      [[inputs.modbus.request]]
-        slave_id = 1
-        byte_order = "ABCD"
-        register = "holding"
-        measurement = "daikin"
-        fields = [
-          {name = "set_lwt_heating_add",   address = 62, type = "INT16", scale = 1.0},  # off 63: °C
-          {name = "set_lwt_cooling_add",   address = 63, type = "INT16", scale = 1.0},  # off 64: °C
-          {name = "set_wd_mode_add",       address = 64, type = "INT16", scale = 1.0},  # off 65: 0..3
-          {name = "set_wd_heat_offset_add",address = 65, type = "INT16", scale = 1.0},  # off 66: -10..10 °C
-          {name = "set_wd_cool_offset_add",address = 66, type = "INT16", scale = 1.0}   # off 67: -10..10 °C
+          {name = "set_dhw_booster_onoff", address = 12, type = "INT16", scale = 1.0}   # off 13: 0/1
         ]
 {{- end }}

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -1,8 +1,8 @@
 # Daikin heat pump (Modbus) — ACTIVE. Home Hub EKRHH reachable at 192.168.1.131:502
 # (slave_id 1); the full §9.2 register map in templates/configmap-daikin.yaml was
-# verified live against the unit (all 8 request blocks read, no IllegalDataAddress).
-# Registers currently return the §9.2.3 "wait for value"/"unsupported" sentinels
-# until the heat pump delivers live data — filter downstream (see telegraf/DAIKIN-MODBUS.md).
+# verified live against the unit. All 59 fields remain enabled across five
+# priority classes (10 s / 30 s / 60 s / 5 min / 1 h); see DAIKIN-MODBUS.md.
+# Unsupported equipment can return §9.2.3 sentinel values; filter downstream.
 daikin:
   enabled: true
 


### PR DESCRIPTION
## Summary

- split all 59 HomeHub fields into five polling priorities based on operational relevance and observed change frequency
- keep metric names unchanged and force `optimization = "none"` so Telegraf never fills register gaps
- stagger polls with per-input jitter and document the active production configuration

Telegraf remains read-only, including holding registers.

## Validation

- `helm lint ./telegraf`
- Helm render parsed as TOML: 5 inputs, 12 requests, 59 fields
- field-name set compared with the previous config: no additions or removals
- rendered config accepted by `telegraf:1.39-alpine config check --strict-env-handling`