### PR TITLE
perf(telegraf): tier FoxESS Modbus polling

### DIFF
--- a/telegraf/FOXESS-MODBUS.md
+++ b/telegraf/FOXESS-MODBUS.md
@@ -1,0 +1,80 @@
+# FoxESS H3 Smart — Modbus integration
+
+Telegraf reads the FoxESS H3 Smart through the cluster-local evcc Modbus proxy
+at `tcp://evcc:502`, logical device/slave ID `247`. evcc owns and serializes the
+physical inverter connection; Telegraf must not open five independent direct
+connections to the inverter. The mapping follows FoxESS *Modbus definition
+V1.05.04.00*, tables 3-3 through 3-6. All configured registers are documented
+`RO`; Telegraf uses FC03 only and has no write path.
+
+## Polling priorities
+
+The original input read all 57 fields every 10 seconds. VictoriaMetrics showed
+that power-flow values changed almost every sample, while totals and inventory
+values changed orders of magnitude less often. The configuration therefore
+uses five independent inputs:
+
+| Priority | Interval | Fields | Purpose |
+|----------|----------|--------|---------|
+| P0 safety | 10 s | 12 | Inverter/BMS status, off-grid state and alarm/fault bitfields |
+| P1 power | 10 s | 24 | CT1, inverter/load phase power, PV1 and inverter-side battery data |
+| P2 health | 30 s | 16 | Grid quality, inverter temperature and BMS operating data |
+| P3 energy | 60 s | 8 | Monotonic lifetime energy counters |
+| P4 inventory | 5 min | 4 | Export availability, SOH, FCC and design energy |
+
+All previous 57 metric names remain unchanged. Seven safety metrics were added:
+
+- `foxess_inverter_status_3` — protocol register 39065/39066, including the
+  off-grid bit.
+- `foxess_battery_bms_fault_1` through `_fault_6` — registers 37626–37631.
+
+Every request explicitly sets `optimization = "none"`, so Telegraf never fills
+gaps with reserved or otherwise unselected registers. Per-input
+`collection_jitter` spreads the Modbus traffic.
+
+## Expected load
+
+Based on Telegraf's current request partitioning, the tiered configuration keeps
+the fast operational signals while reducing the steady-state load approximately
+as follows:
+
+| Measure | Before | Tiered |
+|---------|-------:|-------:|
+| Existing field samples/day | 492,480 | 309,312 |
+| All field samples/day | 492,480 | 369,792 |
+| Modbus transactions/day | 241,920 | 130,752 |
+| Holding-register words/day | 768,960 | 571,680 |
+
+The seven additional P0 fields intentionally trade a small amount of the saving
+for better fault coverage. Even with them included, field samples fall by about
+25%, transactions by 46%, and read register words by 26%.
+
+## Reload behavior
+
+The upstream Telegraf chart hashes only its primary ConfigMap. The values file
+therefore carries the SHA-256 of the rendered FoxESS `modbus.conf` as a pod
+annotation, which forces a rollout when the mapping changes. Telegraf also runs
+with `--watch-config poll --watch-interval 10s` so projected ConfigMap updates
+are reloaded if an annotation update is accidentally missed.
+
+When editing `templates/configmap.yaml`, update
+`telegraf.podAnnotations.checksum/foxess-modbus-config` to the SHA-256 of the
+rendered `modbus.conf`.
+
+## Validation
+
+Before merging:
+
+1. `helm lint ./telegraf`
+2. Render and parse `modbus.conf` with Telegraf's config checker.
+3. Assert five inputs, 13 request definitions and 64 unique fields.
+4. Compare the 57 established field names with the previous revision.
+5. Run all five inputs read-only against `tcp://evcc:502`; a direct parallel
+   test against the inverter is invalid because of its TCP-client limit.
+
+After ArgoCD sync:
+
+1. Confirm the application revision and a new Telegraf pod.
+2. Check startup logs for aliases `foxess_safety`, `foxess_power`,
+   `foxess_health`, `foxess_energy` and `foxess_inventory` without Modbus errors.
+3. Confirm all 64 metrics in VictoriaMetrics and verify their sample cadence.

--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -3,6 +3,12 @@
 - [Documentation](https://docs.influxdata.com/telegraf/)
 - [Helm Chart](https://github.com/influxdata/helm-charts/tree/master/charts/telegraf)
 
+## Modbus integrations
+
+- [FoxESS H3 Smart](FOXESS-MODBUS.md) — prioritized read-only polling of power,
+  grid/BMS health, energy totals and inventory registers.
+- [Daikin Home Hub](DAIKIN-MODBUS.md) — prioritized read-only heat-pump polling.
+
 ## Helm install
 ```
 helm install telegraf .

--- a/telegraf/templates/configmap.yaml
+++ b/telegraf/templates/configmap.yaml
@@ -6,162 +6,230 @@ metadata:
     app.kubernetes.io/name: telegraf
 data:
   modbus.conf: |
+    # FoxESS H3 Smart via Modbus TCP. All registers below are documented RO
+    # registers from FoxESS Modbus definition V1.05.04.00. Telegraf only uses
+    # FC03 reads; it has no Modbus write configuration.
+    #
+    # Polling is tiered by operational relevance and observed change rate.
+    # Every request explicitly disables gap filling so reserved registers are
+    # never read implicitly.
+
+    # P0 — safety and connectivity. Rare changes must be visible quickly.
     [[inputs.modbus]]
+      alias = "foxess_safety"
       name = "foxess"
       controller = "${MODBUS_CONTROLLER}"
       configuration_type = "request"
       interval = "10s"
+      collection_jitter = "1s"
       timeout = "5s"
       busy_retries = 3
       busy_retries_wait = "500ms"
       [inputs.modbus.tags]
         inverter = "foxess_h3_smart"
 
-      # ── Netz / Meter CT1 (38xxx) ─────────────────────────────────────────
-      # Tab. 3-4: Meter1/CT1 Ströme, Wirkleistung, Blindleistung
-      # Vorzeichen-Konvention: negativ = Einspeisung, positiv = Bezug
-      [[inputs.modbus.request]]
-        slave_id = 247
-        byte_order = "ABCD"
-        register = "holding"
-        measurement = "foxess_grid_meter"
-        fields = [
-          # Ströme (A; gain=1000)
-          {name = "current_l1",    address = 38808, type = "INT32",  scale = 0.001},
-          {name = "current_l2",    address = 38810, type = "INT32",  scale = 0.001},
-          {name = "current_l3",    address = 38812, type = "INT32",  scale = 0.001},
-          # Kombinierte Wirkleistung (W; gain=10)
-          {name = "meter_active",  address = 38814, type = "INT32",  scale = -0.1},
-          # Phasenwirkleistungen (W; gain=10, invertiertes Vorzeichen)
-          {name = "l1",            address = 38816, type = "INT32",  scale = -0.1},
-          {name = "l2",            address = 38818, type = "INT32",  scale = -0.1},
-          {name = "l3",            address = 38820, type = "INT32",  scale = -0.1},
-          # Blindleistung (Var; gain=10)
-          {name = "reactive_power",address = 38822, type = "INT32",  scale = 0.1}
-        ]
-
-      # ── Netz / Wechselrichter-seitig (39xxx) ─────────────────────────────
-      # Tab. 3-5: Netzspannungen, Ströme, Frequenz vom Wechselrichter
-      [[inputs.modbus.request]]
-        slave_id = 247
-        byte_order = "ABCD"
-        register = "holding"
-        measurement = "foxess_grid"
-        fields = [
-          # Netzspannungen (V; gain=10)
-          {name = "voltage_l1",         address = 39123, type = "INT16",  scale = 0.1},
-          {name = "voltage_l2",         address = 39124, type = "INT16",  scale = 0.1},
-          {name = "voltage_l3",         address = 39125, type = "INT16",  scale = 0.1},
-          # Wechselrichter-Ausgangsströme (A; gain=1000)
-          {name = "inverter_current_l1",address = 39126, type = "INT32",  scale = 0.001},
-          {name = "inverter_current_l2",address = 39128, type = "INT32",  scale = 0.001},
-          {name = "inverter_current_l3",address = 39130, type = "INT32",  scale = 0.001},
-          # Netzfrequenz (Hz; gain=100)
-          {name = "frequency",          address = 39139, type = "INT16",  scale = 0.01}
-        ]
-
-      # ── Wechselrichter-AC-Ausgang ────────────────────────────────────────
-      # Tab. 3-5 (39xxx): Status, Leistung, Last
+      # Inverter operation, off-grid state and alarms (table 3-5).
       [[inputs.modbus.request]]
         slave_id = 247
         byte_order = "ABCD"
         register = "holding"
         measurement = "foxess_inverter"
+        optimization = "none"
         fields = [
-          # Status (Bitfield: Bit0=Standby, Bit2=Operation, Bit6=Fault)
-          {name = "status",         address = 39063, type = "UINT16", scale = 1.0},
-          # Alarm-Register
-          {name = "alarm_1",        address = 39067, type = "UINT16", scale = 1.0},
-          {name = "alarm_2",        address = 39068, type = "UINT16", scale = 1.0},
-          {name = "alarm_3",        address = 39069, type = "UINT16", scale = 1.0},
-          # Wirkleistung (W; gain=1000)
-          {name = "active_power",   address = 39134, type = "INT32",  scale = 1.0},
-          # Blindleistung (Var; gain=1000)
-          {name = "reactive_power", address = 39136, type = "INT32",  scale = 1.0},
-          # Leistungsfaktor (gain=1000)
-          {name = "power_factor",   address = 39138, type = "INT16",  scale = 0.001},
-          # Innentemperatur (°C; gain=10)
-          {name = "temperature",    address = 39141, type = "INT16",  scale = 0.1},
-          # Lastleistung pro Phase (W; gain=1)
-          {name = "load_l1",        address = 39219, type = "INT32",  scale = 1.0},
-          {name = "load_l2",        address = 39221, type = "INT32",  scale = 1.0},
-          {name = "load_l3",        address = 39223, type = "INT32",  scale = 1.0},
-          # Lastleistung kombiniert (W; gain=1)
-          {name = "load_power",     address = 39225, type = "INT32",  scale = 1.0},
-          # INV Phasenleistung (W; gain=1)
-          {name = "power_l1",       address = 39248, type = "INT32",  scale = 1.0},
-          {name = "power_l2",       address = 39250, type = "INT32",  scale = 1.0},
-          {name = "power_l3",       address = 39252, type = "INT32",  scale = 1.0},
-          # Verfügbare Exportleistung (W; gain=1)
-          {name = "available_export",address = 39277, type = "INT32",  scale = 1.0}
+          {name = "status",   address = 39063, type = "UINT16", scale = 1.0},  # Status1: standby/operation/fault
+          {name = "status_3", address = 39065, type = "UINT32", scale = 1.0},  # Status3: bit 0 off-grid
+          {name = "alarm_1",  address = 39067, type = "UINT16", scale = 1.0},
+          {name = "alarm_2",  address = 39068, type = "UINT16", scale = 1.0},
+          {name = "alarm_3",  address = 39069, type = "UINT16", scale = 1.0}
         ]
 
-      # ── PV-String 1 ─────────────────────────────────────────────────────
-      # Tab. 3-5 (39xxx): nur PV1 angeschlossen
-      [[inputs.modbus.request]]
-        slave_id = 247
-        byte_order = "ABCD"
-        register = "holding"
-        measurement = "foxess_pv"
-        fields = [
-          # PV1 (V gain=10, A gain=100, W gain=1)
-          {name = "pv1_voltage", address = 39070, type = "INT16",  scale = 0.1},
-          {name = "pv1_current", address = 39071, type = "INT16",  scale = 0.01},
-          {name = "pv1_power",   address = 39279, type = "INT32",  scale = 1.0}
-        ]
-
-      # ── Batterie BMS (37xxx) ─────────────────────────────────────────────
-      # Tab. 3-3: BMS1 Status, Rohdaten direkt vom BMS
+      # BMS connection and raw fault bitfields (table 3-3).
       [[inputs.modbus.request]]
         slave_id = 247
         byte_order = "ABCD"
         register = "holding"
         measurement = "foxess_battery_bms"
+        optimization = "none"
         fields = [
-          # BMS1 Connection Status (0=Offline, 1=Online)
-          {name = "bms_status",    address = 37002, type = "UINT16", scale = 1.0},
-          # BMS1 Rohdaten (direkt vom BMS gemeldet)
-          {name = "voltage",       address = 37609, type = "UINT16", scale = 0.1},
-          {name = "current",       address = 37610, type = "INT16",  scale = 0.1},
-          {name = "temperature",   address = 37611, type = "INT16",  scale = 0.1},
-          {name = "soc",           address = 37612, type = "UINT16", scale = 1.0},
-          {name = "soh",           address = 37624, type = "UINT16", scale = 1.0},
-          {name = "temp_max",      address = 37617, type = "INT16",  scale = 0.1},
-          {name = "temp_min",      address = 37618, type = "INT16",  scale = 0.1},
-          {name = "cell_v_max",    address = 37619, type = "UINT16", scale = 1.0},
-          {name = "cell_v_min",    address = 37620, type = "UINT16", scale = 1.0},
-          # remain_energy (37632) entfernt: BMS meldet konstant design_energy
-          # unabhängig vom SoC → keine Aussagekraft (Restenergie via soc/100 * design_energy ableiten)
-          # Full Charge Capacity (Ah; gain=10 → scale=0.1)
-          {name = "fcc_capacity",  address = 37633, type = "UINT16", scale = 0.1},
-          # Design-Energie (Wh; gain=0.1 → scale=10.0)
-          {name = "design_energy", address = 37635, type = "UINT16", scale = 10.0}
+          {name = "bms_status", address = 37002, type = "UINT16", scale = 1.0}  # 0 offline / 1 online
         ]
 
-      # ── Batterie Wechselrichter-seitig (39xxx) ────────────────────────────
-      # Tab. 3-5: Spannung, Strom, Leistung vom Wechselrichter gemessen
-      # Vorzeichen (WR-seitig, Protokoll 39228/39237): positiv = Entladen, negativ = Laden
-      #   Achtung: Gegenkonvention zur BMS-Strommessung (37610: positiv = Laden)
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_battery_bms"
+        optimization = "none"
+        fields = [
+          {name = "fault_1", address = 37626, type = "UINT16", scale = 1.0},
+          {name = "fault_2", address = 37627, type = "UINT16", scale = 1.0},
+          {name = "fault_3", address = 37628, type = "UINT16", scale = 1.0},
+          {name = "fault_4", address = 37629, type = "UINT16", scale = 1.0},
+          {name = "fault_5", address = 37630, type = "UINT16", scale = 1.0},
+          {name = "fault_6", address = 37631, type = "UINT16", scale = 1.0}
+        ]
+
+    # P1 — fast power-flow signals used by responsive dashboards and analysis.
+    [[inputs.modbus]]
+      alias = "foxess_power"
+      name = "foxess"
+      controller = "${MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "10s"
+      collection_jitter = "2s"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      [inputs.modbus.tags]
+        inverter = "foxess_h3_smart"
+
+      # Meter1/CT1 currents and power (table 3-4).
+      # Sign convention after scaling: negative export, positive import.
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_grid_meter"
+        optimization = "none"
+        fields = [
+          {name = "current_l1",     address = 38808, type = "INT32", scale = 0.001},
+          {name = "current_l2",     address = 38810, type = "INT32", scale = 0.001},
+          {name = "current_l3",     address = 38812, type = "INT32", scale = 0.001},
+          {name = "meter_active",   address = 38814, type = "INT32", scale = -0.1},
+          {name = "l1",             address = 38816, type = "INT32", scale = -0.1},
+          {name = "l2",             address = 38818, type = "INT32", scale = -0.1},
+          {name = "l3",             address = 38820, type = "INT32", scale = -0.1},
+          {name = "reactive_power", address = 38822, type = "INT32", scale = 0.1}
+        ]
+
+      # Inverter output and load power (table 3-5).
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_inverter"
+        optimization = "none"
+        fields = [
+          {name = "active_power",   address = 39134, type = "INT32", scale = 1.0},
+          {name = "reactive_power", address = 39136, type = "INT32", scale = 1.0},
+          {name = "power_factor",   address = 39138, type = "INT16", scale = 0.001},
+          {name = "load_l1",        address = 39219, type = "INT32", scale = 1.0},
+          {name = "load_l2",        address = 39221, type = "INT32", scale = 1.0},
+          {name = "load_l3",        address = 39223, type = "INT32", scale = 1.0},
+          {name = "load_power",     address = 39225, type = "INT32", scale = 1.0},
+          {name = "power_l1",       address = 39248, type = "INT32", scale = 1.0},
+          {name = "power_l2",       address = 39250, type = "INT32", scale = 1.0},
+          {name = "power_l3",       address = 39252, type = "INT32", scale = 1.0}
+        ]
+
+      # PV string 1 (only installed string).
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_pv"
+        optimization = "none"
+        fields = [
+          {name = "pv1_voltage", address = 39070, type = "INT16", scale = 0.1},
+          {name = "pv1_current", address = 39071, type = "INT16", scale = 0.01},
+          {name = "pv1_power",   address = 39279, type = "INT32", scale = 1.0}
+        ]
+
+      # Battery as measured by the inverter. Positive current/power means
+      # discharging; negative means charging.
       [[inputs.modbus.request]]
         slave_id = 247
         byte_order = "ABCD"
         register = "holding"
         measurement = "foxess_battery"
+        optimization = "none"
         fields = [
           {name = "voltage", address = 39227, type = "INT16", scale = 0.1},
           {name = "current", address = 39228, type = "INT32", scale = 0.001},
           {name = "power",   address = 39237, type = "INT32", scale = 1.0}
         ]
 
-      # ── Energiezähler (nur _total) ────────────────────────────────────────
-      # Tab. 3-5 (39149+) + Tab. 3-6 (39601+); alle in kWh (gain=100 → scale=0.01)
-      # _today-Register entfernt: tägl. Reset erzeugt Sprünge, increase(_total) ist besser
-      # output_total entfernt: identisch mit generation_total
+    # P2 — grid quality and BMS health. Dynamic, but 10-second resolution adds
+    # mostly measurement noise rather than useful information.
+    [[inputs.modbus]]
+      alias = "foxess_health"
+      name = "foxess"
+      controller = "${MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "30s"
+      collection_jitter = "5s"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      [inputs.modbus.tags]
+        inverter = "foxess_h3_smart"
+
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_grid"
+        optimization = "none"
+        fields = [
+          {name = "voltage_l1",          address = 39123, type = "INT16", scale = 0.1},
+          {name = "voltage_l2",          address = 39124, type = "INT16", scale = 0.1},
+          {name = "voltage_l3",          address = 39125, type = "INT16", scale = 0.1},
+          {name = "inverter_current_l1", address = 39126, type = "INT32", scale = 0.001},
+          {name = "inverter_current_l2", address = 39128, type = "INT32", scale = 0.001},
+          {name = "inverter_current_l3", address = 39130, type = "INT32", scale = 0.001},
+          {name = "frequency",           address = 39139, type = "INT16", scale = 0.01}
+        ]
+
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_inverter"
+        optimization = "none"
+        fields = [
+          {name = "temperature", address = 39141, type = "INT16", scale = 0.1}
+        ]
+
+      # BMS current uses the opposite sign convention to the inverter-side
+      # current: positive means charging, negative means discharging.
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_battery_bms"
+        optimization = "none"
+        fields = [
+          {name = "voltage",     address = 37609, type = "UINT16", scale = 0.1},
+          {name = "current",     address = 37610, type = "INT16",  scale = 0.1},
+          {name = "temperature", address = 37611, type = "INT16",  scale = 0.1},
+          {name = "soc",         address = 37612, type = "UINT16", scale = 1.0},
+          {name = "temp_max",    address = 37617, type = "INT16",  scale = 0.1},
+          {name = "temp_min",    address = 37618, type = "INT16",  scale = 0.1},
+          {name = "cell_v_max",  address = 37619, type = "UINT16", scale = 1.0},
+          {name = "cell_v_min",  address = 37620, type = "UINT16", scale = 1.0}
+        ]
+
+    # P3 — monotonic energy totals. The inverter updates these far less often
+    # than the current 10-second poll. Daily counters are deliberately omitted.
+    [[inputs.modbus]]
+      alias = "foxess_energy"
+      name = "foxess"
+      controller = "${MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "60s"
+      collection_jitter = "10s"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      [inputs.modbus.tags]
+        inverter = "foxess_h3_smart"
+
       [[inputs.modbus.request]]
         slave_id = 247
         byte_order = "ABCD"
         register = "holding"
         measurement = "foxess_energy"
+        optimization = "none"
         fields = [
           {name = "generation_total",        address = 39149, type = "UINT32", scale = 0.01},
           {name = "pv_total",                address = 39601, type = "UINT32", scale = 0.01},
@@ -171,4 +239,42 @@ data:
           {name = "grid_import_total",       address = 39617, type = "UINT32", scale = 0.01},
           {name = "input_total",             address = 39625, type = "UINT32", scale = 0.01},
           {name = "load_total",              address = 39629, type = "UINT32", scale = 0.01}
+        ]
+
+    # P4 — inventory and very slow BMS/configuration values.
+    [[inputs.modbus]]
+      alias = "foxess_inventory"
+      name = "foxess"
+      controller = "${MODBUS_CONTROLLER}"
+      configuration_type = "request"
+      interval = "5m"
+      collection_jitter = "30s"
+      timeout = "5s"
+      busy_retries = 3
+      busy_retries_wait = "500ms"
+      [inputs.modbus.tags]
+        inverter = "foxess_h3_smart"
+
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_inverter"
+        optimization = "none"
+        fields = [
+          {name = "available_export", address = 39277, type = "INT32", scale = 1.0}
+        ]
+
+      # remain_energy is intentionally not read: this installation reported
+      # design_energy regardless of SoC. Derive it from SoC and design_energy.
+      [[inputs.modbus.request]]
+        slave_id = 247
+        byte_order = "ABCD"
+        register = "holding"
+        measurement = "foxess_battery_bms"
+        optimization = "none"
+        fields = [
+          {name = "soh",           address = 37624, type = "UINT16", scale = 1.0},
+          {name = "fcc_capacity",  address = 37633, type = "UINT16", scale = 0.1},
+          {name = "design_energy", address = 37635, type = "UINT16", scale = 10.0}
         ]

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -7,6 +7,11 @@ daikin:
   enabled: true
 
 telegraf:
+  # The upstream chart only hashes its primary ConfigMap. Keep this annotation
+  # equal to the rendered modbus.conf SHA-256 so FoxESS changes also roll the pod.
+  podAnnotations:
+    checksum/foxess-modbus-config: "857da7a20b619b3c03922d7f6aa5c67140c8a659d4930573623eccc97de9cc90"
+
   service:
     enabled: false
   pdb:
@@ -14,8 +19,10 @@ telegraf:
   env:
     - name: VICTORIA_METRICS_URL
       value: "http://vmsingle-vm:8428"
+    # FoxESS accepts only a small number of direct TCP clients. The evcc proxy
+    # owns the inverter connection and serializes the five Telegraf poll tiers.
     - name: MODBUS_CONTROLLER
-      value: "tcp://192.168.107.186:502"
+      value: "tcp://evcc:502"
     # Daikin Home Hub EKRHH (TCP port 502 plain / 802 TLS, or RTU serial file://):
     - name: DAIKIN_MODBUS_CONTROLLER
       value: "tcp://192.168.1.131:502"
@@ -117,6 +124,12 @@ telegraf:
   args:
     - --config
     - /etc/telegraf/telegraf.conf
+    # ConfigMap volumes update in place. Polling lets Telegraf reload external
+    # Modbus config directories even if a future annotation bump is missed.
+    - --watch-config
+    - poll
+    - --watch-interval
+    - "10s"
     - --config-directory
     - /etc/telegraf/conf.d
     # Daikin Home Hub EKRHH Modbus input:


### PR DESCRIPTION
## What changed

- split FoxESS H3 Smart polling into five priority tiers (10s, 30s, 60s, 5m)
- preserve all 57 existing metrics and add Status3 plus six BMS fault bitfields
- disable request gap filling explicitly with `optimization = "none"`
- route Telegraf through the existing evcc Modbus proxy
- add a rollout checksum, config polling, and integration documentation

## Why

Power-flow metrics change quickly, while health, lifetime totals, and inventory values do not need a 10-second cadence. The previous input generated unnecessary Modbus and VictoriaMetrics load. Multiple direct TCP clients also cause FoxESS reads to fail with EOF, so the five tiers use evcc's serialized proxy connection.

## Expected impact

- 64 read-only FC03 metrics (57 preserved + 7 safety fields)
- field samples: 492,480/day -> 369,792/day (-25%)
- Modbus transactions: 241,920/day -> 130,752/day (-46%)
- register words: 768,960/day -> 571,680/day (-26%)

## Validation

- `git diff --check`
- `helm lint ./telegraf`
- rendered Helm chart successfully
- Telegraf 1.39.2 `config check`: 5 inputs, 13 requests, 64 fields
- all five inputs read successfully in parallel through the live evcc proxy, including Status3 and BMS fault_1..fault_6
