### PR TITLE
fix(telegraf): serialize FoxESS poll tiers

### DIFF
--- a/telegraf/FOXESS-MODBUS.md
+++ b/telegraf/FOXESS-MODBUS.md
@@ -29,8 +29,10 @@ All previous 57 metric names remain unchanged. Seven safety metrics were added:
 - `foxess_battery_bms_fault_1` through `_fault_6` — registers 37626–37631.
 
 Every request explicitly sets `optimization = "none"`, so Telegraf never fills
-gaps with reserved or otherwise unselected registers. Per-input
-`collection_jitter` spreads the Modbus traffic.
+gaps with reserved or otherwise unselected registers. Fixed per-input
+`collection_offset` values place the five pollers at 0, 2, 4, 6 and 8 seconds
+within their interval. This is required because random jitter still allowed
+simultaneous requests and the FoxESS connection responded with sporadic `EOF`.
 
 ## Expected load
 

--- a/telegraf/templates/configmap.yaml
+++ b/telegraf/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       controller = "${MODBUS_CONTROLLER}"
       configuration_type = "request"
       interval = "10s"
-      collection_jitter = "1s"
+      collection_offset = "0s"
       timeout = "5s"
       busy_retries = 3
       busy_retries_wait = "500ms"
@@ -76,7 +76,7 @@ data:
       controller = "${MODBUS_CONTROLLER}"
       configuration_type = "request"
       interval = "10s"
-      collection_jitter = "2s"
+      collection_offset = "2s"
       timeout = "5s"
       busy_retries = 3
       busy_retries_wait = "500ms"
@@ -157,7 +157,7 @@ data:
       controller = "${MODBUS_CONTROLLER}"
       configuration_type = "request"
       interval = "30s"
-      collection_jitter = "5s"
+      collection_offset = "4s"
       timeout = "5s"
       busy_retries = 3
       busy_retries_wait = "500ms"
@@ -217,7 +217,7 @@ data:
       controller = "${MODBUS_CONTROLLER}"
       configuration_type = "request"
       interval = "60s"
-      collection_jitter = "10s"
+      collection_offset = "6s"
       timeout = "5s"
       busy_retries = 3
       busy_retries_wait = "500ms"
@@ -248,7 +248,7 @@ data:
       controller = "${MODBUS_CONTROLLER}"
       configuration_type = "request"
       interval = "5m"
-      collection_jitter = "30s"
+      collection_offset = "8s"
       timeout = "5s"
       busy_retries = 3
       busy_retries_wait = "500ms"

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -10,7 +10,7 @@ telegraf:
   # The upstream chart only hashes its primary ConfigMap. Keep this annotation
   # equal to the rendered modbus.conf SHA-256 so FoxESS changes also roll the pod.
   podAnnotations:
-    checksum/foxess-modbus-config: "857da7a20b619b3c03922d7f6aa5c67140c8a659d4930573623eccc97de9cc90"
+    checksum/foxess-modbus-config: "6f34f73681e91e5e1595add7c7a8525a241c977c3b4b6928e55c87a4424dcea5"
 
   service:
     enabled: false


### PR DESCRIPTION
## What changed

- replace random polling jitter with fixed offsets at 0, 2, 4, 6 and 8 seconds
- update the rendered FoxESS ConfigMap checksum
- document why the proxy-facing requests must not overlap

## Root cause

The first rollout successfully produced all 64 FoxESS metrics, but runtime verification found sporadic `EOF` failures in `foxess_health` and `foxess_energy`. The independent Telegraf inputs could still issue simultaneous requests despite random jitter. The evcc proxy uses one physical FoxESS connection, and that connection is not reliable with overlapping downstream requests.

## Validation

- `git diff --check`
- `helm lint ./telegraf`
- rendered chart contains the five fixed offsets and matching ConfigMap checksum
- Telegraf 1.39.2 accepts `collection_offset` for all five inputs
- request partition remains unchanged: 5 inputs, 13 requests, 64 fields

After merge, ArgoCD rollout will be observed through at least one complete five-minute inventory interval. Telegraf internal gather errors, logs, raw sample cadence, and VictoriaMetrics ingestion will be checked.
