### PR TITLE
fix(telegraf): avoid FoxESS proxy EOFs

### DIFF
--- a/telegraf/FOXESS-MODBUS.md
+++ b/telegraf/FOXESS-MODBUS.md
@@ -1,9 +1,7 @@
 # FoxESS H3 Smart — Modbus integration
 
-Telegraf reads the FoxESS H3 Smart through the cluster-local evcc Modbus proxy
-at `tcp://evcc:502`, logical device/slave ID `247`. evcc owns and serializes the
-physical inverter connection; Telegraf must not open five independent direct
-connections to the inverter. The mapping follows FoxESS *Modbus definition
+Telegraf reads the FoxESS H3 Smart directly at `tcp://192.168.107.186:502`,
+logical device/slave ID `247`. The mapping follows FoxESS *Modbus definition
 V1.05.04.00*, tables 3-3 through 3-6. All configured registers are documented
 `RO`; Telegraf uses FC03 only and has no write path.
 
@@ -33,6 +31,11 @@ gaps with reserved or otherwise unselected registers. Fixed per-input
 `collection_offset` values place the five pollers at 0, 2, 4, 6 and 8 seconds
 within their interval. This is required because random jitter still allowed
 simultaneous requests and the FoxESS connection responded with sporadic `EOF`.
+Each tier also sets `close_connection_after_gather = true`, so the five inputs
+do not hold five direct TCP connections open. At most one Telegraf connection
+is active at a time. The evcc Modbus proxy is deliberately not used: live
+rollout tests still produced upstream `EOF` responses after Telegraf's own
+requests had been serialized.
 
 ## Expected load
 
@@ -71,8 +74,9 @@ Before merging:
 2. Render and parse `modbus.conf` with Telegraf's config checker.
 3. Assert five inputs, 13 request definitions and 64 unique fields.
 4. Compare the 57 established field names with the previous revision.
-5. Run all five inputs read-only against `tcp://evcc:502`; a direct parallel
-   test against the inverter is invalid because of its TCP-client limit.
+5. Assert fixed offsets and `close_connection_after_gather = true` on all five
+   inputs; direct parallel one-shot tests are invalid because they ignore the
+   runtime offsets and exceed the inverter's TCP-client budget.
 
 After ArgoCD sync:
 

--- a/telegraf/templates/configmap.yaml
+++ b/telegraf/templates/configmap.yaml
@@ -69,6 +69,12 @@ data:
           {name = "fault_6", address = 37631, type = "UINT16", scale = 1.0}
         ]
 
+      # Five poll tiers share the FoxESS TCP-client budget. Their fixed offsets
+      # prevent overlap; disconnecting after each gather leaves only one
+      # Telegraf connection open at a time.
+      [inputs.modbus.workarounds]
+        close_connection_after_gather = true
+
     # P1 — fast power-flow signals used by responsive dashboards and analysis.
     [[inputs.modbus]]
       alias = "foxess_power"
@@ -149,6 +155,9 @@ data:
           {name = "power",   address = 39237, type = "INT32", scale = 1.0}
         ]
 
+      [inputs.modbus.workarounds]
+        close_connection_after_gather = true
+
     # P2 — grid quality and BMS health. Dynamic, but 10-second resolution adds
     # mostly measurement noise rather than useful information.
     [[inputs.modbus]]
@@ -209,6 +218,9 @@ data:
           {name = "cell_v_min",  address = 37620, type = "UINT16", scale = 1.0}
         ]
 
+      [inputs.modbus.workarounds]
+        close_connection_after_gather = true
+
     # P3 — monotonic energy totals. The inverter updates these far less often
     # than the current 10-second poll. Daily counters are deliberately omitted.
     [[inputs.modbus]]
@@ -240,6 +252,9 @@ data:
           {name = "input_total",             address = 39625, type = "UINT32", scale = 0.01},
           {name = "load_total",              address = 39629, type = "UINT32", scale = 0.01}
         ]
+
+      [inputs.modbus.workarounds]
+        close_connection_after_gather = true
 
     # P4 — inventory and very slow BMS/configuration values.
     [[inputs.modbus]]
@@ -278,3 +293,6 @@ data:
           {name = "fcc_capacity",  address = 37633, type = "UINT16", scale = 0.1},
           {name = "design_energy", address = 37635, type = "UINT16", scale = 10.0}
         ]
+
+      [inputs.modbus.workarounds]
+        close_connection_after_gather = true

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -10,7 +10,7 @@ telegraf:
   # The upstream chart only hashes its primary ConfigMap. Keep this annotation
   # equal to the rendered modbus.conf SHA-256 so FoxESS changes also roll the pod.
   podAnnotations:
-    checksum/foxess-modbus-config: "6f34f73681e91e5e1595add7c7a8525a241c977c3b4b6928e55c87a4424dcea5"
+    checksum/foxess-modbus-config: "73a583465434e37c98bd94678785d7e2b21f3b269d8a8a52b00c3447b89af770"
 
   service:
     enabled: false
@@ -19,10 +19,10 @@ telegraf:
   env:
     - name: VICTORIA_METRICS_URL
       value: "http://vmsingle-vm:8428"
-    # FoxESS accepts only a small number of direct TCP clients. The evcc proxy
-    # owns the inverter connection and serializes the five Telegraf poll tiers.
+    # The five tiers use fixed offsets and close after every gather, so only one
+    # Telegraf connection occupies the FoxESS TCP-client budget at a time.
     - name: MODBUS_CONTROLLER
-      value: "tcp://evcc:502"
+      value: "tcp://192.168.107.186:502"
     # Daikin Home Hub EKRHH (TCP port 502 plain / 802 TLS, or RTU serial file://):
     - name: DAIKIN_MODBUS_CONTROLLER
       value: "tcp://192.168.1.131:502"


### PR DESCRIPTION
## What changed

- move FoxESS polling from the evcc proxy back to the proven direct inverter endpoint
- keep the five fixed collection offsets
- close each Modbus connection after its gather cycle so only one Telegraf connection is active at a time
- update documentation and the rendered ConfigMap checksum

## Root cause

PR #2336 eliminated overlap between the five Telegraf inputs, but the post-ArgoCD live test still observed an `EOF` from the evcc proxy on the isolated energy offset. The proxy/upstream path itself is therefore unreliable for this workload. The original single direct Telegraf input was stable, so the tiered configuration now preserves the device's connection budget by combining fixed offsets with `close_connection_after_gather = true`.

## Validation

- `git diff --check`
- `helm lint ./telegraf`
- Telegraf 1.39.2 config check: 5 inputs, 13 requests, 64 fields
- rendered checksum matches the rollout annotation
- all five tiers were executed individually and sequentially against the live direct endpoint; all reads succeeded with no errors

After merge, ArgoCD and the new pod will be observed for a complete five-minute inventory cycle. Telegraf internal gather counters, logs, raw cadence, all 64 VictoriaMetrics series, and the seven new safety values will be verified.
