### PR TITLE
Archive Open-Meteo forecasts in VictoriaMetrics

### DIFF
--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -9,6 +9,29 @@
   grid/BMS health, energy totals and inventory registers.
 - [Daikin Home Hub](DAIKIN-MODBUS.md) — prioritized read-only heat-pump polling.
 
+## Daikin forecast history
+
+The MQTT consumer stores the retained
+`daikin-altherma-esp32/weather/openmeteo/forecast` document as measurement
+`daikin_weather_openmeteo_forecast` in VictoriaMetrics. Numeric payload keys become series such as:
+
+- `daikin_weather_openmeteo_forecast_outdoor_mean_2h_c`
+- `daikin_weather_openmeteo_forecast_solar_energy_2h_wh_m2`
+- `daikin_weather_openmeteo_forecast_available` and
+  `daikin_weather_openmeteo_forecast_fresh`
+- `daikin_weather_openmeteo_forecast_fetched_unix_s`,
+  `daikin_weather_openmeteo_forecast_forecast_start_unix_s`, and
+  `daikin_weather_openmeteo_forecast_valid_until_unix_s`
+
+Only the stable `provider` and `model` values tag these numeric series. The categorical snapshot
+context (`state`, `reason`, `freshness_reason`, and `error`) is stored separately on
+`daikin_weather_openmeteo_forecast_info_schema`. This prevents changing status labels from forking
+every numeric forecast series and leaving an obsolete label set behind.
+Telegraf's receive time is the metric timestamp; the source and forecast timestamps remain fields,
+so a retained replay cannot silently rewrite when the historian actually observed the snapshot.
+Analysis must require both `available == 1` and `fresh == 1`. An unavailable snapshot may still
+carry the last figures for forensic comparison and must not be interpreted as a usable forecast.
+
 ## Helm install
 ```
 helm install telegraf .

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -90,11 +90,12 @@ telegraf:
           topic_tag: "topic"
           data_format: "json"
       # ── Daikin Altherma ESP32 (X10A-Bridge) ──────────────────────────────
-      # Firmware daikin-altherma-esp32 publiziert drei JSON-Topics unter
+      # Firmware daikin-altherma-esp32 publiziert vier JSON-Topics unter
       # <base> = "daikin-altherma-esp32" (CONFIG_DAIKIN_MQTT_BASE_TOPIC):
       #   <base>/x10a      - gruppiertes X10A-JSON, on-change (retained)
       #   <base>/modbus    - HomeHub-Modbus-JSON, on-change (retained)
       #   <base>/heartbeat - flache Board-/Link-Diagnose, fester 10s-Takt
+      #   <base>/weather/openmeteo/forecast - atomarer Prognose-/Provenienz-Snapshot (retained)
       # /status, /modbus/status (Verfügbarkeit) und /crash sind kein Metrik-JSON und
       # werden bewusst nicht abonniert (Parser würde fehlschlagen).
       #
@@ -119,6 +120,45 @@ telegraf:
           servers: ["tcp://mosquitto:1883"]
           topics: ["daikin-altherma-esp32/heartbeat"]
           data_format: "json"
+          tags:
+            device: "daikin-altherma-esp32"
+      # Telegraf-Empfangszeit bleibt der Sample-Zeitpunkt in VictoriaMetrics. Die
+      # Payload-Zeitstempel bleiben gleichzeitig numerische Felder: so ist sowohl
+      # rekonstruierbar, wann der Snapshot archiviert wurde, als auch wann die
+      # Firmware ihn abgerufen hat und bis wann er entscheidungsfähig war.
+      # `available`/`fresh` müssen jede spätere Auswertung fail-closed begrenzen;
+      # ein Fehler-Snapshot darf seine letzten Zahlen nur als Diagnose behalten.
+      # Nur stabile Provider-/Modell-Tags hängen an den numerischen Zeitreihen. Wechselnde
+      # Zustände und Fehler landen in einer separaten Info-Serie, damit ein Statuswechsel keine
+      # alten numerischen Label-Sets (z.B. available=1) zurücklässt.
+      - mqtt_consumer:
+          name_override: "daikin_weather_openmeteo_forecast"
+          servers: ["tcp://mosquitto:1883"]
+          topics: ["daikin-altherma-esp32/weather/openmeteo/forecast"]
+          topic_tag: "topic"
+          data_format: "json"
+          fieldexclude:
+            - "schema"
+          tag_keys:
+            - "provider"
+            - "model"
+          tags:
+            device: "daikin-altherma-esp32"
+      - mqtt_consumer:
+          name_override: "daikin_weather_openmeteo_forecast_info"
+          servers: ["tcp://mosquitto:1883"]
+          topics: ["daikin-altherma-esp32/weather/openmeteo/forecast"]
+          topic_tag: "topic"
+          data_format: "json"
+          fieldinclude:
+            - "schema"
+          tag_keys:
+            - "provider"
+            - "model"
+            - "state"
+            - "reason"
+            - "freshness_reason"
+            - "error"
           tags:
             device: "daikin-altherma-esp32"
 


### PR DESCRIPTION
## What changed

- Consume `daikin-altherma-esp32/weather/openmeteo/forecast` in Telegraf.
- Store numeric forecast evidence as `daikin_weather_openmeteo_forecast` fields.
- Store changing status/error context separately as
  `daikin_weather_openmeteo_forecast_info_schema`.
- Keep only stable `provider` and `model` tags on numeric time series.

## Why

VictoriaMetrics needs the exact forecast and provenance known to the firmware so later analysis can
reconstruct why a control decision was made. Separating changing status tags prevents needless
numeric series forks.

## Validation

- `helm lint --strict telegraf`
- `helm template telegraf telegraf`
- Telegraf 1.39.2 parser smoke test with representative firmware JSON

