### PR TITLE
Archive Meross thermostat state in VictoriaMetrics

### DIFF
--- a/telegraf/Chart.yaml
+++ b/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: telegraf
 type: application
-version: 1.0.66
+version: 1.0.67
 # renovate: image=telegraf
 appVersion: "1.39.2"
 dependencies: 

--- a/telegraf/MEROSS-MQTT.md
+++ b/telegraf/MEROSS-MQTT.md
@@ -1,0 +1,58 @@
+# Meross thermostat MQTT archive
+
+`templates/configmap-meross.yaml` archives the raw publisher view required by
+`0Bu/daikin-altherma-esp32#288`.
+
+## Contract
+
+- MQTT scope: `meross-thermostat-bot/mts200b/+/state`
+- measurement: `meross_thermostat`
+- stable tags: `device_id`, `model`, `topic`, `source`
+- fields: `current_temperature_c`, `target_temperature_c`, `enabled`, `active`
+- timestamp: the original RFC3339 `thermostat.read_at`, rounded to the agent's whole-second
+  precision; Telegraf arrival time is deliberately not substituted
+- state encoding: `enabled` and `active` are integer `1`/`0` after the converter
+
+The UUID from the payload/topic is the device identity. Pod name, mDNS instance,
+host address, preset, HVAC mode, and mutable display labels are not tags, keeping
+cardinality bounded. Missing current or target values reject the whole raw metric
+because both JSON-v2 fields are required.
+
+The firmware-accepted view remains on the existing
+`daikin-altherma-esp32/heartbeat` input and appears under measurement
+`daikin_heartbeat` as:
+
+- `room_temperature_c`, `room_setpoint_c`, `room_error_k`
+- `room_temperature_valid`, `room_setpoint_valid`, `room_control_eligible`
+- `room_source_unix_s`, `room_age_s`, `room_reason_code`
+- `room_calibration_k` (fixed `0`)
+
+This intentionally gives two queryable histories: raw `meross_thermostat_*` says
+what the local poller emitted; `daikin_heartbeat_room_*` says what the firmware
+accepted at heartbeat time.
+
+## Verification
+
+Run the pinned parser fixture:
+
+```sh
+telegraf/tests/verify-meross-parser.sh
+```
+
+The test asserts the exact `read_at` second as metric time, stable identity, both temperatures, and
+numeric `enabled`/`active` output. Then render the chart:
+
+```sh
+helm dependency build telegraf
+helm lint telegraf
+helm template telegraf telegraf
+```
+
+After Argo CD reports `Synced` and `Healthy`, verify both views in VictoriaMetrics:
+
+```promql
+meross_thermostat_current_temperature_c{device_id="<uuid>"}
+meross_thermostat_target_temperature_c{device_id="<uuid>"}
+daikin_heartbeat_room_control_eligible{device="daikin-altherma-esp32"}
+daikin_heartbeat_room_reason_code{device="daikin-altherma-esp32"}
+```

--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -32,6 +32,12 @@ so a retained replay cannot silently rewrite when the historian actually observe
 Analysis must require both `available == 1` and `fresh == 1`. An unavailable snapshot may still
 carry the last figures for forensic comparison and must not be interpreted as a usable forecast.
 
+## Meross room history
+
+[MEROSS-MQTT.md](MEROSS-MQTT.md) documents the bounded MTS200 MQTT input, source-time extraction,
+stable series identity, parser fixture, and the distinction between raw Meross observations and the
+firmware-accepted `daikin_heartbeat_room_*` view.
+
 ## Helm install
 ```
 helm install telegraf .

--- a/telegraf/templates/configmap-meross.yaml
+++ b/telegraf/templates/configmap-meross.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telegraf-meross-mqtt
+  labels:
+    app.kubernetes.io/name: telegraf
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  meross.conf: |-
+    # Raw observation contract for issue 0Bu/daikin-altherma-esp32#288.
+    # The wildcard is bounded to one model and one state document per stable Meross UUID.
+    [[inputs.mqtt_consumer]]
+      servers = ["tcp://mosquitto:1883"]
+      topics = ["meross-thermostat-bot/mts200b/+/state"]
+      topic_tag = "topic"
+      data_format = "json_v2"
+
+      [inputs.mqtt_consumer.tags]
+        source = "meross-thermostat-bot"
+
+      [[inputs.mqtt_consumer.json_v2]]
+        measurement_name = "meross_thermostat"
+        timestamp_path = "thermostat.read_at"
+        timestamp_format = "2006-01-02T15:04:05.999999999Z07:00"
+
+        [[inputs.mqtt_consumer.json_v2.tag]]
+          path = "device_id"
+          rename = "device_id"
+          type = "string"
+
+        [[inputs.mqtt_consumer.json_v2.tag]]
+          path = "thermostat.model"
+          rename = "model"
+          type = "string"
+
+        [[inputs.mqtt_consumer.json_v2.field]]
+          path = "thermostat.current_temperature_c"
+          rename = "current_temperature_c"
+          type = "float"
+
+        [[inputs.mqtt_consumer.json_v2.field]]
+          path = "thermostat.target_temperature_c"
+          rename = "target_temperature_c"
+          type = "float"
+
+        [[inputs.mqtt_consumer.json_v2.field]]
+          path = "thermostat.enabled"
+          rename = "enabled"
+          type = "bool"
+
+        [[inputs.mqtt_consumer.json_v2.field]]
+          path = "thermostat.active"
+          rename = "active"
+          type = "bool"
+
+    # VictoriaMetrics' Influx receiver keeps numeric fields. Convert the two JSON booleans to
+    # stable 1/0 integers after parsing; Telegraf 1.39.2's converter explicitly maps bool this way.
+    [[processors.converter]]
+      namepass = ["meross_thermostat"]
+      [processors.converter.fields]
+        integer = ["enabled", "active"]

--- a/telegraf/tests/meross-parser.conf
+++ b/telegraf/tests/meross-parser.conf
@@ -6,7 +6,7 @@
   data_format = "json_v2"
   [inputs.file.tags]
     source = "meross-thermostat-bot"
-    topic = "meross-thermostat-bot/mts200b/2206242745222660120148e1e999d026/state"
+    topic = "meross-thermostat-bot/mts200b/0123456789abcdef0123456789abcdef/state"
 
   [[inputs.file.json_v2]]
     measurement_name = "meross_thermostat"

--- a/telegraf/tests/meross-parser.conf
+++ b/telegraf/tests/meross-parser.conf
@@ -1,0 +1,49 @@
+[agent]
+  omit_hostname = true
+
+[[inputs.file]]
+  files = ["/tests/meross-state.json"]
+  data_format = "json_v2"
+  [inputs.file.tags]
+    source = "meross-thermostat-bot"
+    topic = "meross-thermostat-bot/mts200b/2206242745222660120148e1e999d026/state"
+
+  [[inputs.file.json_v2]]
+    measurement_name = "meross_thermostat"
+    timestamp_path = "thermostat.read_at"
+    timestamp_format = "2006-01-02T15:04:05.999999999Z07:00"
+
+    [[inputs.file.json_v2.tag]]
+      path = "device_id"
+      rename = "device_id"
+      type = "string"
+
+    [[inputs.file.json_v2.tag]]
+      path = "thermostat.model"
+      rename = "model"
+      type = "string"
+
+    [[inputs.file.json_v2.field]]
+      path = "thermostat.current_temperature_c"
+      rename = "current_temperature_c"
+      type = "float"
+
+    [[inputs.file.json_v2.field]]
+      path = "thermostat.target_temperature_c"
+      rename = "target_temperature_c"
+      type = "float"
+
+    [[inputs.file.json_v2.field]]
+      path = "thermostat.enabled"
+      rename = "enabled"
+      type = "bool"
+
+    [[inputs.file.json_v2.field]]
+      path = "thermostat.active"
+      rename = "active"
+      type = "bool"
+
+[[processors.converter]]
+  namepass = ["meross_thermostat"]
+  [processors.converter.fields]
+    integer = ["enabled", "active"]

--- a/telegraf/tests/meross-state.json
+++ b/telegraf/tests/meross-state.json
@@ -1,0 +1,15 @@
+{
+  "schema": "meross.thermostat.v1",
+  "device_id": "2206242745222660120148e1e999d026",
+  "source": "local_http_poll",
+  "thermostat": {
+    "read_at": "2026-08-04T12:00:00.123456789Z",
+    "uuid": "2206242745222660120148e1e999d026",
+    "model": "mts200b",
+    "enabled": true,
+    "active": false,
+    "hvac_mode": "heat",
+    "current_temperature_c": 21.1,
+    "target_temperature_c": 22.5
+  }
+}

--- a/telegraf/tests/meross-state.json
+++ b/telegraf/tests/meross-state.json
@@ -1,10 +1,10 @@
 {
   "schema": "meross.thermostat.v1",
-  "device_id": "2206242745222660120148e1e999d026",
+  "device_id": "0123456789abcdef0123456789abcdef",
   "source": "local_http_poll",
   "thermostat": {
     "read_at": "2026-08-04T12:00:00.123456789Z",
-    "uuid": "2206242745222660120148e1e999d026",
+    "uuid": "0123456789abcdef0123456789abcdef",
     "model": "mts200b",
     "enabled": true,
     "active": false,

--- a/telegraf/tests/verify-meross-parser.sh
+++ b/telegraf/tests/verify-meross-parser.sh
@@ -6,7 +6,7 @@ output=$(docker run --rm -v "$tests_dir:/tests:ro" telegraf:1.39.2-alpine \
   telegraf --config /tests/meross-parser.conf --test 2>&1)
 printf '%s\n' "$output"
 
-printf '%s\n' "$output" | grep -q 'meross_thermostat,device_id=2206242745222660120148e1e999d026'
+printf '%s\n' "$output" | grep -q 'meross_thermostat,device_id=0123456789abcdef0123456789abcdef'
 printf '%s\n' "$output" | grep -q 'model=mts200b'
 printf '%s\n' "$output" | grep -q 'current_temperature_c=21.1'
 printf '%s\n' "$output" | grep -q 'target_temperature_c=22.5'

--- a/telegraf/tests/verify-meross-parser.sh
+++ b/telegraf/tests/verify-meross-parser.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+tests_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+output=$(docker run --rm -v "$tests_dir:/tests:ro" telegraf:1.39.2-alpine \
+  telegraf --config /tests/meross-parser.conf --test 2>&1)
+printf '%s\n' "$output"
+
+printf '%s\n' "$output" | grep -q 'meross_thermostat,device_id=2206242745222660120148e1e999d026'
+printf '%s\n' "$output" | grep -q 'model=mts200b'
+printf '%s\n' "$output" | grep -q 'current_temperature_c=21.1'
+printf '%s\n' "$output" | grep -q 'target_temperature_c=22.5'
+printf '%s\n' "$output" | grep -q 'enabled=1i'
+printf '%s\n' "$output" | grep -q 'active=0i'
+printf '%s\n' "$output" | grep -q '1785844800000000000$'

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -176,6 +176,9 @@ telegraf:
     # Daikin Home Hub EKRHH Modbus input:
     - --config-directory
     - /etc/telegraf/daikin.d
+    # Raw Meross MTS200 observations use their publisher-side read_at as the metric timestamp.
+    - --config-directory
+    - /etc/telegraf/meross.d
 
   volumes:
     - name: telegraf-modbus
@@ -184,9 +187,14 @@ telegraf:
     - name: telegraf-modbus-daikin
       configMap:
         name: telegraf-modbus-daikin
+    - name: telegraf-meross-mqtt
+      configMap:
+        name: telegraf-meross-mqtt
 
   mountPoints:
     - name: telegraf-modbus
       mountPath: /etc/telegraf/conf.d
     - name: telegraf-modbus-daikin
       mountPath: /etc/telegraf/daikin.d
+    - name: telegraf-meross-mqtt
+      mountPath: /etc/telegraf/meross.d


### PR DESCRIPTION
## What changed

- add a narrow Telegraf MQTT consumer for `meross-thermostat-bot/mts200b/+/state`
- archive current/target temperature plus enabled/active under measurement `meross_thermostat`
- preserve `thermostat.read_at` as metric time and use stable UUID/model/source/topic identity
- convert boolean state to numeric 1/0 for VictoriaMetrics
- mount the input as a separate ConfigMap/config directory and bump the chart to 1.0.67
- document raw versus firmware-accepted series and add a pinned parser fixture

## Why

The Meross poller and retained MQTT documents are already live, but the raw publisher view required by `0Bu/daikin-altherma-esp32#288` was not being written to VictoriaMetrics.

## Validation

- `telegraf/tests/verify-meross-parser.sh` using `telegraf:1.39.2-alpine`
- `helm lint telegraf`
- `helm template telegraf telegraf`
- `git diff --check`

The parser fixture verifies both temperatures, UUID/model identity, numeric enabled/active fields, and the exact source timestamp.
