### PR TITLE
Ingest Daikin heating-curve MQTT telemetry

### DIFF
--- a/telegraf/Chart.yaml
+++ b/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: telegraf
 type: application
-version: 1.0.67
+version: 1.0.68
 # renovate: image=telegraf
 appVersion: "1.39.2"
 dependencies: 

--- a/telegraf/DAIKIN-HEATING-CURVE-MQTT.md
+++ b/telegraf/DAIKIN-HEATING-CURVE-MQTT.md
@@ -1,0 +1,61 @@
+# Daikin heating-curve MQTT archive
+
+The Daikin ESP32 publishes accepted room evidence and its read-only heating-curve diagnosis as a
+separate, non-retained domain snapshot. Telegraf archives it independently from the technical
+heartbeat.
+
+## Contract
+
+- MQTT topic: `daikin-altherma-esp32/heating_curve`
+- firmware schema: numeric top-level `schema_version` (currently `1`)
+- VictoriaMetrics measurement: `daikin_heating_curve`
+- stable tag: `device="daikin-altherma-esp32"`
+- metric timestamp: Telegraf receive time
+- cadence: approximately 10 seconds while the firmware's X10A publication gate is open
+- retention: the MQTT document is not retained; a restarted consumer waits for the next live snapshot
+
+The legacy Telegraf JSON parser joins nested object paths with `_`. Representative fields are:
+
+- `room_temperature_c`, `room_setpoint_c`, `room_error_k`
+- `room_temperature_valid`, `room_setpoint_valid`, `room_control_eligible`
+- `room_source_unix_s`, `room_age_s`, `room_reason_code`
+- `room_counters_messages`, `room_counters_errors`, `room_counters_rejections`
+- `diagnosis_method_version`, `diagnosis_state`, `diagnosis_reason`
+- `diagnosis_gates_plant_known`, `diagnosis_gates_plant_active`
+- `diagnosis_gates_heating_mode_known`, `diagnosis_gates_heating_mode_active`
+- `diagnosis_room_evidence_current_error_k`, `diagnosis_room_evidence_source_unix_s`
+- `diagnosis_last_sample_room_error_k`, `diagnosis_last_sample_unix_s`,
+  `diagnosis_last_sample_sequence`
+- `diagnosis_counters_evaluations`, `diagnosis_counters_samples`,
+  `diagnosis_counters_holds`, `diagnosis_counters_blocks`
+
+Firmware validity and gate booleans are encoded as numeric `1`/`0`, so the numeric-only archive
+keeps them. JSON `null` means unavailable evidence and produces no field for that snapshot; it must
+never be interpreted as a measured zero. `room.source_id` is descriptive text and is deliberately
+not promoted to a tag, keeping series identity bounded. Source and sample Unix timestamps remain
+numeric fields; they do not replace Telegraf's receive time.
+
+## Verification
+
+Run the pinned parser fixture and chart checks:
+
+```sh
+telegraf/tests/verify-daikin-heating-curve-parser.sh
+helm dependency build telegraf
+helm lint telegraf
+helm template telegraf telegraf
+```
+
+The fixture verifies nested flattening, numeric booleans, the fixed device tag, and omission of
+unavailable (`null`) evidence. After Argo CD reports `Synced` and `Healthy`, verify the ready
+Telegraf pod and real series:
+
+```promql
+daikin_heating_curve_schema_version{device="daikin-altherma-esp32"}
+daikin_heating_curve_room_control_eligible{device="daikin-altherma-esp32"}
+daikin_heating_curve_diagnosis_state{device="daikin-altherma-esp32"}
+daikin_heating_curve_diagnosis_counters_evaluations{device="daikin-altherma-esp32"}
+```
+
+Room- or heating-curve-prefixed fields under `daikin_heartbeat_*` indicate a producer or deployment
+regression; the heartbeat contract is board/link health only.

--- a/telegraf/MEROSS-MQTT.md
+++ b/telegraf/MEROSS-MQTT.md
@@ -18,9 +18,9 @@ host address, preset, HVAC mode, and mutable display labels are not tags, keepin
 cardinality bounded. Missing current or target values reject the whole raw metric
 because both JSON-v2 fields are required.
 
-The firmware-accepted view remains on the existing
-`daikin-altherma-esp32/heartbeat` input and appears under measurement
-`daikin_heartbeat` as:
+The firmware-accepted view is archived from the dedicated
+`daikin-altherma-esp32/heating_curve` input and appears under measurement
+`daikin_heating_curve` as:
 
 - `room_temperature_c`, `room_setpoint_c`, `room_error_k`
 - `room_temperature_valid`, `room_setpoint_valid`, `room_control_eligible`
@@ -28,8 +28,12 @@ The firmware-accepted view remains on the existing
 - `room_calibration_k` (fixed `0`)
 
 This intentionally gives two queryable histories: raw `meross_thermostat_*` says
-what the local poller emitted; `daikin_heartbeat_room_*` says what the firmware
-accepted at heartbeat time.
+what the local poller emitted; `daikin_heating_curve_room_*` says what the firmware
+accepted at heating-curve snapshot time. The technical heartbeat deliberately no
+longer carries room or heating-curve fields.
+
+The complete nested-field and null-handling contract is documented in
+[`DAIKIN-HEATING-CURVE-MQTT.md`](DAIKIN-HEATING-CURVE-MQTT.md).
 
 ## Verification
 
@@ -53,6 +57,6 @@ After Argo CD reports `Synced` and `Healthy`, verify both views in VictoriaMetri
 ```promql
 meross_thermostat_current_temperature_c{device_id="<uuid>"}
 meross_thermostat_target_temperature_c{device_id="<uuid>"}
-daikin_heartbeat_room_control_eligible{device="daikin-altherma-esp32"}
-daikin_heartbeat_room_reason_code{device="daikin-altherma-esp32"}
+daikin_heating_curve_room_control_eligible{device="daikin-altherma-esp32"}
+daikin_heating_curve_room_reason_code{device="daikin-altherma-esp32"}
 ```

--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -36,7 +36,14 @@ carry the last figures for forensic comparison and must not be interpreted as a 
 
 [MEROSS-MQTT.md](MEROSS-MQTT.md) documents the bounded MTS200 MQTT input, source-time extraction,
 stable series identity, parser fixture, and the distinction between raw Meross observations and the
-firmware-accepted `daikin_heartbeat_room_*` view.
+firmware-accepted `daikin_heating_curve_room_*` view.
+
+## Daikin heating-curve diagnosis history
+
+[DAIKIN-HEATING-CURVE-MQTT.md](DAIKIN-HEATING-CURVE-MQTT.md) documents the dedicated
+`daikin-altherma-esp32/heating_curve` input, its `daikin_heating_curve` measurement, nested-field
+flattening, null semantics, bounded tag set, parser fixture, and live VictoriaMetrics checks. The
+technical `daikin_heartbeat` measurement remains limited to board and link health.
 
 ## Helm install
 ```

--- a/telegraf/tests/heating-curve-parser.conf
+++ b/telegraf/tests/heating-curve-parser.conf
@@ -1,0 +1,9 @@
+[agent]
+  omit_hostname = true
+
+[[inputs.file]]
+  files = ["/tests/heating-curve.json"]
+  name_override = "daikin_heating_curve"
+  data_format = "json"
+  [inputs.file.tags]
+    device = "daikin-altherma-esp32"

--- a/telegraf/tests/heating-curve.json
+++ b/telegraf/tests/heating-curve.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "room": {
+    "source_id": "living_room",
+    "calibration_k": 0,
+    "temperature_valid": 1,
+    "setpoint_valid": 1,
+    "control_eligible": 1,
+    "temperature_c": 22.6,
+    "setpoint_c": 22.0,
+    "error_k": -0.6,
+    "source_unix_s": 1786062003,
+    "age_s": 0,
+    "reason_code": 0,
+    "counters": {
+      "messages": 6,
+      "errors": 0,
+      "rejections": 1
+    }
+  },
+  "diagnosis": {
+    "method_version": 2,
+    "armed": 1,
+    "state": 2,
+    "reason": 9,
+    "sample_eligible": 0,
+    "forecast_available": 1,
+    "gates": {
+      "plant_known": 1,
+      "plant_active": 0,
+      "heating_mode_known": 1,
+      "heating_mode_active": 1
+    },
+    "room_evidence": {
+      "current_error_k": null,
+      "source_unix_s": 1786062003,
+      "age_s": 0
+    },
+    "last_sample": {
+      "room_error_k": null,
+      "unix_s": null,
+      "sequence": 0
+    },
+    "counters": {
+      "evaluations": 75,
+      "samples": 0,
+      "holds": 74,
+      "blocks": 1
+    }
+  }
+}

--- a/telegraf/tests/verify-daikin-heating-curve-parser.sh
+++ b/telegraf/tests/verify-daikin-heating-curve-parser.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+tests_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+output=$(docker run --rm -v "$tests_dir:/tests:ro" telegraf:1.39.2-alpine \
+  telegraf --config /tests/heating-curve-parser.conf --test 2>&1)
+printf '%s\n' "$output"
+
+printf '%s\n' "$output" | grep -q 'daikin_heating_curve,device=daikin-altherma-esp32'
+printf '%s\n' "$output" | grep -q 'schema_version=1'
+printf '%s\n' "$output" | grep -q 'room_temperature_c=22.6'
+printf '%s\n' "$output" | grep -q 'room_control_eligible=1'
+printf '%s\n' "$output" | grep -q 'room_counters_rejections=1'
+printf '%s\n' "$output" | grep -q 'diagnosis_gates_plant_active=0'
+printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_sequence=0'
+printf '%s\n' "$output" | grep -q 'diagnosis_counters_evaluations=75'
+
+if printf '%s\n' "$output" | grep -qE \
+  'source_id|diagnosis_room_evidence_current_error_k|diagnosis_last_sample_(room_error_k|unix_s)'; then
+  echo 'unexpected text or null-valued field in numeric metric' >&2
+  exit 1
+fi

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -91,11 +91,12 @@ telegraf:
           topic_tag: "topic"
           data_format: "json"
       # ── Daikin Altherma ESP32 (X10A-Bridge) ──────────────────────────────
-      # Firmware daikin-altherma-esp32 publiziert vier JSON-Topics unter
+      # Firmware daikin-altherma-esp32 publiziert fuenf Metrik-JSON-Topics unter
       # <base> = "daikin-altherma-esp32" (CONFIG_DAIKIN_MQTT_BASE_TOPIC):
       #   <base>/x10a      - gruppiertes X10A-JSON, on-change (retained)
       #   <base>/modbus    - HomeHub-Modbus-JSON, on-change (retained)
       #   <base>/heartbeat - flache Board-/Link-Diagnose, fester 10s-Takt
+      #   <base>/heating_curve - gruppierte Raum-/Heizkurven-Diagnose, fester 10s-Takt
       #   <base>/weather/openmeteo/forecast - atomarer Prognose-/Provenienz-Snapshot (retained)
       # /status, /modbus/status (Verfügbarkeit) und /crash sind kein Metrik-JSON und
       # werden bewusst nicht abonniert (Parser würde fehlschlagen).
@@ -120,6 +121,17 @@ telegraf:
           name_override: "daikin_heartbeat"
           servers: ["tcp://mosquitto:1883"]
           topics: ["daikin-altherma-esp32/heartbeat"]
+          data_format: "json"
+          tags:
+            device: "daikin-altherma-esp32"
+      # Eigenes Measurement fuer den fachlichen Raum-/Heizkurven-Snapshot. Der
+      # Legacy-JSON-Parser flacht Objektpfade mit "_" ab; JSON null wird als
+      # nicht vorhandenes Feld verworfen. Die Firmware sendet Booleans bereits
+      # numerisch als 1/0, damit sie in VictoriaMetrics erhalten bleiben.
+      - mqtt_consumer:
+          name_override: "daikin_heating_curve"
+          servers: ["tcp://mosquitto:1883"]
+          topics: ["daikin-altherma-esp32/heating_curve"]
           data_format: "json"
           tags:
             device: "daikin-altherma-esp32"


### PR DESCRIPTION
## Summary

- subscribe Telegraf to `daikin-altherma-esp32/heating_curve` as `daikin_heating_curve`
- document nested-field flattening, receive-time, numeric boolean, null and bounded-tag contracts
- move the Meross accepted-room history references away from the technical heartbeat
- add a pinned real-shape parser fixture and bump the chart to `1.0.68`

## Verification

- `telegraf/tests/verify-daikin-heating-curve-parser.sh`
- `telegraf/tests/verify-meross-parser.sh`
- `helm dependency build telegraf`
- `helm lint telegraf`
- `helm template telegraf telegraf` (render contains the new measurement and exact topic)

## Delivery

After merge, verify Argo CD `Synced`/`Healthy`, the replacement Telegraf pod, and real `daikin_heating_curve_*` series in VictoriaMetrics.