### PR TITLE
feat(telegraf): subscribe to two shellyplugpmg3 devices via MQTT

### DIFF
--- a/telegraf/templates/configmap-shelly-mqtt.yaml
+++ b/telegraf/templates/configmap-shelly-mqtt.yaml
@@ -23,6 +23,7 @@ data:
         "shelly3em63g3-e4b063f32e48/status/#",
         "shellyplugsg3-d0cf13d87ed8/status/#",
         "shellyplugsg3-d0cf13c856a0/status/#",
-        "shellyplugpmg3-907069519650/status/#"
+        "shellyplugpmg3-907069519650/status/#",
+        "shellyplugpmg3-9070695c1d18/status/#"
       ]
       data_format = "json"

--- a/telegraf/templates/configmap-shelly-mqtt.yaml
+++ b/telegraf/templates/configmap-shelly-mqtt.yaml
@@ -22,6 +22,7 @@ data:
         "shellypill-d885ac1a6284/status/#",
         "shelly3em63g3-e4b063f32e48/status/#",
         "shellyplugsg3-d0cf13d87ed8/status/#",
-        "shellyplugsg3-d0cf13c856a0/status/#"
+        "shellyplugsg3-d0cf13c856a0/status/#",
+        "shellyplugpmg3-907069519650/status/#"
       ]
       data_format = "json"


### PR DESCRIPTION
Adds two Shelly Plug PM Gen3 devices to the Telegraf MQTT consumer so their status metrics are ingested alongside the other Shelly devices.

## Changes

- `telegraf/templates/configmap-shelly-mqtt.yaml`: added `shellyplugpmg3-907069519650/status/#` and `shellyplugpmg3-9070695c1d18/status/#` to the `inputs.mqtt_consumer` topic list.

No other config changes were needed — the devices join the existing `shelly` measurement via `name_override`, and the mount/volume wiring for the Shelly config directory already exists in `telegraf/values.yaml`.