### PR TITLE
Add heating-curve diagnosis v2 rules

### DIFF
--- a/telegraf/tests/heating-curve.json
+++ b/telegraf/tests/heating-curve.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "room": {
     "source_id": "living_room",
     "calibration_k": 0,
@@ -25,6 +25,7 @@
     "reason": 9,
     "sample_eligible": 0,
     "forecast_available": 1,
+    "outdoor_available": 1,
     "gates": {
       "plant_known": 1,
       "plant_active": 0,
@@ -37,9 +38,10 @@
       "age_s": 0
     },
     "last_sample": {
-      "room_error_k": null,
-      "unix_s": null,
-      "sequence": 0
+      "room_error_k": 0.4,
+      "outdoor_temperature_c": -4.25,
+      "unix_s": 1786060200,
+      "sequence": 1
     },
     "counters": {
       "evaluations": 75,

--- a/telegraf/tests/heating-curve.json
+++ b/telegraf/tests/heating-curve.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "room": {
     "source_id": "living_room",
     "calibration_k": 0,
@@ -26,6 +26,11 @@
     "sample_eligible": 0,
     "forecast_available": 1,
     "outdoor_available": 1,
+    "outdoor_source": "env3",
+    "outdoor_source_code": 3,
+    "plant_outdoor_available": 1,
+    "plant_outdoor_source": "homehub",
+    "plant_outdoor_source_code": 2,
     "gates": {
       "plant_known": 1,
       "plant_active": 0,
@@ -40,6 +45,11 @@
     "last_sample": {
       "room_error_k": 0.4,
       "outdoor_temperature_c": -4.25,
+      "outdoor_source": "env3",
+      "outdoor_source_code": 3,
+      "plant_outdoor_temperature_c": -5.5,
+      "plant_outdoor_source": "homehub",
+      "plant_outdoor_source_code": 2,
       "unix_s": 1786060200,
       "sequence": 1
     },

--- a/telegraf/tests/verify-daikin-heating-curve-parser.sh
+++ b/telegraf/tests/verify-daikin-heating-curve-parser.sh
@@ -7,16 +7,20 @@ output=$(docker run --rm -v "$tests_dir:/tests:ro" telegraf:1.39.2-alpine \
 printf '%s\n' "$output"
 
 printf '%s\n' "$output" | grep -q 'daikin_heating_curve,device=daikin-altherma-esp32'
-printf '%s\n' "$output" | grep -q 'schema_version=1'
+printf '%s\n' "$output" | grep -q 'schema_version=2'
 printf '%s\n' "$output" | grep -q 'room_temperature_c=22.6'
 printf '%s\n' "$output" | grep -q 'room_control_eligible=1'
 printf '%s\n' "$output" | grep -q 'room_counters_rejections=1'
 printf '%s\n' "$output" | grep -q 'diagnosis_gates_plant_active=0'
-printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_sequence=0'
+printf '%s\n' "$output" | grep -q 'diagnosis_outdoor_available=1'
+printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_room_error_k=0.4'
+printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_outdoor_temperature_c=-4.25'
+printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_unix_s=1786060200'
+printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_sequence=1'
 printf '%s\n' "$output" | grep -q 'diagnosis_counters_evaluations=75'
 
 if printf '%s\n' "$output" | grep -qE \
-  'source_id|diagnosis_room_evidence_current_error_k|diagnosis_last_sample_(room_error_k|unix_s)'; then
+  'source_id|diagnosis_room_evidence_current_error_k'; then
   echo 'unexpected text or null-valued field in numeric metric' >&2
   exit 1
 fi

--- a/telegraf/tests/verify-daikin-heating-curve-parser.sh
+++ b/telegraf/tests/verify-daikin-heating-curve-parser.sh
@@ -7,20 +7,26 @@ output=$(docker run --rm -v "$tests_dir:/tests:ro" telegraf:1.39.2-alpine \
 printf '%s\n' "$output"
 
 printf '%s\n' "$output" | grep -q 'daikin_heating_curve,device=daikin-altherma-esp32'
-printf '%s\n' "$output" | grep -q 'schema_version=2'
+printf '%s\n' "$output" | grep -q 'schema_version=3'
 printf '%s\n' "$output" | grep -q 'room_temperature_c=22.6'
 printf '%s\n' "$output" | grep -q 'room_control_eligible=1'
 printf '%s\n' "$output" | grep -q 'room_counters_rejections=1'
 printf '%s\n' "$output" | grep -q 'diagnosis_gates_plant_active=0'
 printf '%s\n' "$output" | grep -q 'diagnosis_outdoor_available=1'
+printf '%s\n' "$output" | grep -q 'diagnosis_outdoor_source_code=3'
+printf '%s\n' "$output" | grep -q 'diagnosis_plant_outdoor_available=1'
+printf '%s\n' "$output" | grep -q 'diagnosis_plant_outdoor_source_code=2'
 printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_room_error_k=0.4'
 printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_outdoor_temperature_c=-4.25'
+printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_outdoor_source_code=3'
+printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_plant_outdoor_temperature_c=-5.5'
+printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_plant_outdoor_source_code=2'
 printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_unix_s=1786060200'
 printf '%s\n' "$output" | grep -q 'diagnosis_last_sample_sequence=1'
 printf '%s\n' "$output" | grep -q 'diagnosis_counters_evaluations=75'
 
 if printf '%s\n' "$output" | grep -qE \
-  'source_id|diagnosis_room_evidence_current_error_k'; then
+  'source_id|outdoor_source=|plant_outdoor_source=|diagnosis_room_evidence_current_error_k'; then
   echo 'unexpected text or null-valued field in numeric metric' >&2
   exit 1
 fi

--- a/victoria-metrics/Chart.yaml
+++ b/victoria-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: victoria-metrics
 type: application
-version: 1.1.74
+version: 1.1.75
 # renovate: image=victoriametrics/victoria-metrics
 appVersion: "v1.149.0"
 dependencies:

--- a/victoria-metrics/HEATING-CURVE-DIAGNOSIS-V2.md
+++ b/victoria-metrics/HEATING-CURVE-DIAGNOSIS-V2.md
@@ -5,6 +5,10 @@ This is the versioned VictoriaMetrics contract for
 diagnosis method 2; it is not a controller and must not turn room kelvin into a
 leaving-water-temperature correction.
 
+The current domain payload is schema v3. The payload schema and the diagnosis
+method are versioned independently: schema v3 adds source-aware outdoor
+evidence, while the comparable room-error sampling method remains v2.
+
 ## Evidence boundaries
 
 - Select the domain topic `daikin-altherma-esp32/heating_curve` explicitly.
@@ -17,9 +21,12 @@ leaving-water-temperature correction.
 - The reference room has its own thermostat and valves. Its closed inner loop
   can hide an overly high curve, so D1 never stands alone: read D2 clipping and
   D4 thermostat demand beside it.
-- The plant-side outdoor series can freeze while the compressor is off. For
-  the reference installation it may be joined only to confirmed heating
-  evidence. #441 WP4 owns a future source/provenance improvement in firmware.
+- Firmware #441 WP4 supplies two distinct source-aware axes in schema v3:
+  `outdoor_*` is the independent measured/weather context (normally ENV III),
+  while `plant_outdoor_*` is the HomeHub/X10A plant witness. Use the outdoor
+  values stored inside `last_sample`, never a later live reading, when grouping
+  a room-error event. Text source names are dropped by the numeric Telegraf
+  parser; retain the corresponding source codes as provenance.
 
 ## Recorded inputs
 

--- a/victoria-metrics/HEATING-CURVE-DIAGNOSIS-V2.md
+++ b/victoria-metrics/HEATING-CURVE-DIAGNOSIS-V2.md
@@ -1,0 +1,101 @@
+# Heating-curve diagnosis v2
+
+This is the versioned VictoriaMetrics contract for
+`0Bu/daikin-altherma-esp32#294`. It evaluates the firmware's write-free
+diagnosis method 2; it is not a controller and must not turn room kelvin into a
+leaving-water-temperature correction.
+
+## Evidence boundaries
+
+- Select the domain topic `daikin-altherma-esp32/heating_curve` explicitly.
+  Older heartbeat/controller series have different semantics and must not be
+  joined into a v2 verdict.
+- A diagnosis sample is the raw `target - actual` room error. Positive is too
+  cold, negative too warm.
+- Missing or stale evidence is absent, never zero. `plant_inactive` and Cooling
+  are normal `HOLD` states, not failures.
+- The reference room has its own thermostat and valves. Its closed inner loop
+  can hide an overly high curve, so D1 never stands alone: read D2 clipping and
+  D4 thermostat demand beside it.
+- The plant-side outdoor series can freeze while the compressor is off. For
+  the reference installation it may be joined only to confirmed heating
+  evidence. #441 WP4 owns a future source/provenance improvement in firmware.
+
+## Recorded inputs
+
+| Series | Meaning |
+|---|---|
+| `daikin:heating_curve:eligible_heating` | Positive conjunction of armed, plant-known/active and mode-known/Heating gates; absent otherwise |
+| `daikin:heating_curve:sample_room_error_k` | D1 room-error event with at most one 30-minute cadence window of statistical weight |
+| `daikin:heating_curve:clipped_at_35c` | D2 0/1 sample during eligible heating; 35 C is this installation's current main-zone minimum |
+| `daikin:heating_curve:samples_24h` | D3 recorded diagnosis samples in the rolling day |
+| `daikin:heating_curve:expected_eligible_windows_24h` | D3 eligible time expressed as expected half-hour windows |
+| `daikin:heating_curve:room_degree_hours_outside_0_5k_24h` | D4 integrated absolute room error beyond +/-0.5 K, excluding unavailable input |
+
+The three raw Meross `meross_thermostat_active` series remain the D4 zone-demand
+witness. Preserve `device_id`; do not average the three zones into a single
+boolean before calculating each zone's duty cycle.
+
+## D1-D4 report contract
+
+### D1 - directional curve bias
+
+Group `daikin:heating_curve:sample_room_error_k` by the plant-side outdoor
+temperature and the archived two-hour solar-energy context. Initial reporting
+bins are deliberately coarse because the sampler produces at most two events
+per hour:
+
+- outdoor temperature: `<0`, `0..<5`, `5..<10`, `10..<15`, `>=15` C;
+- solar energy over the next two complete hours: `<50`, `50..<200`, `>=200`
+  Wh/m2.
+
+A cell may be described only with at least 24 samples spanning at least three
+different local dates. An outdoor band receives a directional verdict only
+with at least 48 total samples spanning at least seven dates and with no
+opposite-sign median among solar cells that individually pass coverage. Below
+those bars report `insufficient coverage`, not `balanced`.
+
+Report median, interquartile range, sample count and distinct dates. `balanced`
+means the median lies inside +/-0.25 K and both quartiles inside +/-0.5 K. This
+is a room-bias statement, never a numeric LWT setting recommendation.
+
+### D2 - clipping share
+
+For a selected season or outdoor band:
+
+```promql
+avg_over_time(daikin:heating_curve:clipped_at_35c[30d])
+```
+
+State the eligible heating duration beside the percentage. A high share bounds
+what lowering the weather-dependent curve can achieve; it does not by itself
+license changing the installer minimum.
+
+### D3 - coverage and failure reasons
+
+Compare `samples_24h` with `expected_eligible_windows_24h`. Do not calculate a
+ratio when expected windows are zero. Use raw
+`daikin_heating_curve_diagnosis_reason` and the hold/block counter increases to
+explain missing coverage. Idle and Cooling holds stay separate from blocks.
+
+### D4 - comfort and demand context
+
+Report the rolling degree-hours series and, per Meross `device_id`:
+
+```promql
+avg_over_time(meross_thermostat_active[24h])
+```
+
+The duty cycle is corroborating evidence: low room error with valves rarely
+requesting heat can indicate that the inner loop is masking a high curve.
+
+## Alerts
+
+- `DaikinHeatingCurveRoomInputIneligible` requires every plant/heating gate to
+  be positively true and then waits 15 minutes for the room source to recover.
+- `DaikinHeatingCurveDiagnosisBlocked` watches armed diagnosis state 4 for 15
+  minutes, independently of the specific missing witness.
+
+Neither alert fires for the evaluator's normal idle/Cooling `HOLD` state. The
+existing `DaikinEsp32NoData` alert remains responsible for a completely absent
+domain stream.

--- a/victoria-metrics/README.md
+++ b/victoria-metrics/README.md
@@ -13,6 +13,12 @@ helm uninstall victoria-metrics
 
 ## Alerting
 
+The write-free heating-curve diagnosis has a separate evidence and reporting
+contract in [HEATING-CURVE-DIAGNOSIS-V2.md](HEATING-CURVE-DIAGNOSIS-V2.md).
+Its VMRule recording series normalize volatile Telegraf labels and preserve
+the distinction between absence, normal HOLD states and actionable BLOCKED
+states.
+
 ```
 VMRule (templates/vmrule-*.yaml)
   -> vmalert          evaluates the PromQL against VictoriaMetrics
@@ -75,4 +81,3 @@ The payload is the standard Alertmanager webhook format: `status`
 kubectl port-forward -n default svc/vmalert-vm 8080:8080          # rule status
 kubectl port-forward -n default svc/vmalertmanager-vm 9093:9093   # active alerts
 ```
-

--- a/victoria-metrics/templates/vmrule-daikin.yaml
+++ b/victoria-metrics/templates/vmrule-daikin.yaml
@@ -105,8 +105,14 @@ spec:
             sum_over_time(
               clamp_min(
                 abs(
-                  max by (device) (
-                    daikin_heating_curve_room_error_k{topic="daikin-altherma-esp32/heating_curve"}
+                  (
+                    max by (device) (
+                      daikin_heating_curve_room_error_k{topic="daikin-altherma-esp32/heating_curve"}
+                    )
+                    and on (device)
+                    max by (device) (
+                      daikin_heating_curve_room_control_eligible{topic="daikin-altherma-esp32/heating_curve"} == 1
+                    )
                   )
                 ) - 0.5,
                 0

--- a/victoria-metrics/templates/vmrule-daikin.yaml
+++ b/victoria-metrics/templates/vmrule-daikin.yaml
@@ -15,6 +15,104 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   groups:
+    # Stable, device-level inputs for the write-free heating-curve diagnosis v2.
+    # Drop Telegraf's volatile host/db/topic labels here so dashboards and alerts
+    # cannot double-count a pod restart or the retired /state ingestion path.
+    # These rules do not form a verdict; they preserve absence and positive gates.
+    - name: daikin-heating-curve-diagnosis-v2
+      interval: 1m
+      rules:
+        # Positive eligibility witness: absent outside confirmed space heating.
+        - record: daikin:heating_curve:eligible_heating
+          expr: |
+            max by (device) (
+              daikin_heating_curve_diagnosis_armed{topic="daikin-altherma-esp32/heating_curve"} == 1
+            )
+            and on (device)
+            max by (device) (
+              daikin_heating_curve_diagnosis_gates_plant_known{topic="daikin-altherma-esp32/heating_curve"} == 1
+            )
+            and on (device)
+            max by (device) (
+              daikin_heating_curve_diagnosis_gates_plant_active{topic="daikin-altherma-esp32/heating_curve"} == 1
+            )
+            and on (device)
+            max by (device) (
+              daikin_heating_curve_diagnosis_gates_heating_mode_known{topic="daikin-altherma-esp32/heating_curve"} == 1
+            )
+            and on (device)
+            max by (device) (
+              daikin_heating_curve_diagnosis_gates_heating_mode_active{topic="daikin-altherma-esp32/heating_curve"} == 1
+            )
+
+        # D1 input. The firmware repeats the last event in every domain snapshot.
+        # Bound it to the event's 30-minute cadence so a later HOLD/BLOCK cannot
+        # give one old room-error sample days of statistical weight.
+        - record: daikin:heating_curve:sample_room_error_k
+          expr: |
+            max by (device) (
+              daikin_heating_curve_diagnosis_last_sample_room_error_k{topic="daikin-altherma-esp32/heating_curve"}
+            )
+            and on (device)
+            (
+              max by (device) (
+                time() - daikin_heating_curve_diagnosis_last_sample_unix_s{topic="daikin-altherma-esp32/heating_curve"}
+              ) >= 0
+            )
+            and on (device)
+            (
+              max by (device) (
+                time() - daikin_heating_curve_diagnosis_last_sample_unix_s{topic="daikin-altherma-esp32/heating_curve"}
+              ) < 1800
+            )
+
+        # D2 input. Exactly 35 C is the installed main-zone minimum established
+        # by #294. The series exists only during positively confirmed heating;
+        # averaging it therefore yields clipping share of active-heating time.
+        - record: daikin:heating_curve:clipped_at_35c
+          expr: |
+            max by (device) (
+              daikin_altherma_hydronic_lw_setpoint_main{topic="daikin-altherma-esp32/x10a"} == bool 35
+            )
+            and on (device) daikin:heating_curve:eligible_heating
+
+        # D3 inputs. Samples are a monotonic firmware counter; expected windows
+        # are the positively eligible share of a day times 48 half-hour slots.
+        - record: daikin:heating_curve:samples_24h
+          expr: |
+            clamp_min(
+              increase(
+                max by (device) (
+                  daikin_heating_curve_diagnosis_counters_samples{topic="daikin-altherma-esp32/heating_curve"}
+                )[24h:1m]
+              ),
+              0
+            )
+
+        - record: daikin:heating_curve:expected_eligible_windows_24h
+          expr: |
+            avg_over_time(
+              max by (device) (
+                daikin_heating_curve_diagnosis_sample_eligible{topic="daikin-altherma-esp32/heating_curve"}
+              )[24h:1m]
+            ) * 48
+
+        # D4 input. This integrates only real, eligible room-error samples;
+        # missing/stale input contributes no synthetic zero. One subquery point
+        # per minute divided by 60 yields K h outside the +/-0.5 K comfort band.
+        - record: daikin:heating_curve:room_degree_hours_outside_0_5k_24h
+          expr: |
+            sum_over_time(
+              clamp_min(
+                abs(
+                  max by (device) (
+                    daikin_heating_curve_room_error_k{topic="daikin-altherma-esp32/heating_curve"}
+                  )
+                ) - 0.5,
+                0
+              )[24h:1m]
+            ) / 60
+
     - name: daikin-altherma
       interval: 1m
       rules:
@@ -84,3 +182,42 @@ spec:
           annotations:
             summary: {{ `"daikin-altherma-esp32 low on heap: {{ $value }} bytes"` }}
             description: "Free heap dropped far below the usual ~179 KB. The ESP32 will likely reboot soon."
+
+        # #294 diagnosis v2: room evidence matters only while every plant-side
+        # gate positively says SPACE HEATING. Summer idle and Cooling are HOLD,
+        # never alert states. The 15-minute delay exceeds the default 10-minute
+        # source freshness window without turning one delayed poll into noise.
+        - alert: DaikinHeatingCurveRoomInputIneligible
+          expr: |
+            daikin:heating_curve:eligible_heating
+            and on (device)
+            max by (device) (
+              daikin_heating_curve_room_control_eligible{topic="daikin-altherma-esp32/heating_curve"} == 0
+            )
+          for: 15m
+          labels:
+            severity: warning
+            component: heating
+          annotations:
+            summary: "Heating-curve diagnosis has no eligible room input"
+            description: "The plant is positively confirmed active in Heating, but the configured room source has remained stale or ineligible for 15 minutes. Check its MQTT publisher, source timestamp and mapping. Idle and Cooling holds do not trigger this alert."
+
+        # BLOCKED is the evaluator's fail-closed state for missing required
+        # evidence. Keep this separate from the source-specific alert: HomeHub,
+        # plant/mode witnesses, X10A and clock can block the method as well.
+        - alert: DaikinHeatingCurveDiagnosisBlocked
+          expr: |
+            max by (device) (
+              daikin_heating_curve_diagnosis_state{topic="daikin-altherma-esp32/heating_curve"} == 4
+            )
+            and on (device)
+            max by (device) (
+              daikin_heating_curve_diagnosis_armed{topic="daikin-altherma-esp32/heating_curve"} == 1
+            )
+          for: 15m
+          labels:
+            severity: warning
+            component: heating
+          annotations:
+            summary: "Heating-curve diagnosis is blocked"
+            description: "Diagnosis method v2 has lacked required evidence for 15 minutes. Inspect diagnosis_reason and the HomeHub, plant/mode, room, X10A and clock witnesses. Normal plant_inactive and Cooling states are HOLD and do not trigger this alert."


### PR DESCRIPTION
## What changed

- add diagnosis-v2 recording rules for D1-D4 inputs
- add alerts for an ineligible room source during positively confirmed Heating and for a sustained armed BLOCKED state
- keep normal plant-inactive and Cooling HOLD states out of both alerts
- document the initial outdoor/solar bins, minimum coverage, report semantics and closed-inner-loop limitation
- exercise firmware schema v3, including distinct ENV III and HomeHub outdoor provenance and event-paired source codes, in the Telegraf fixture

## Why

The seasonal evidence epic still needs a versioned metrics contract. The existing Grafana dashboard predates diagnosis method v2 and lives only in Grafana's persistent database, so its proposed-offset/saturation interpretation must not become the seasonal verdict.

Refs [0Bu/daikin-altherma-private#3](https://github.com/0Bu/daikin-altherma-private/issues/3) and its source-provenance overlap delivered by [#441 WP4 / PR 0Bu/daikin-altherma-esp32#461](https://github.com/0Bu/daikin-altherma-esp32/pull/461). This is the first GitOps package; versioned Grafana provisioning follows separately.

## Impact

The change adds recording series and two warning rules. It does not write to the heat pump, change a firmware threshold, manufacture a plant state, or deploy a new workload. The current summer HOLD state matches neither alert.

## Validation

- `telegraf/tests/verify-daikin-heating-curve-parser.sh`
- `helm lint --strict victoria-metrics`
- full render of `templates/vmrule-daikin.yaml`
- every new MetricsQL expression parsed against the live VictoriaMetrics instance
- current live state: both alerts empty; D3 zero eligible windows/samples; no rule or series name conflicts
- signed firmware `1.0.0-dev.427` live-tested on bench `.104` with distinct HomeHub/ENV III source display and absence preserved as null
- `git diff --check`