### PR TITLE
Add Shelly Plug S Gen3 to Telegraf

### DIFF
--- a/telegraf/templates/configmap-shelly-mqtt.yaml
+++ b/telegraf/templates/configmap-shelly-mqtt.yaml
@@ -23,6 +23,7 @@ data:
         "shelly3em63g3-e4b063f32e48/status/#",
         "shellyplugsg3-d0cf13d87ed8/status/#",
         "shellyplugsg3-d0cf13c856a0/status/#",
+        "shellyplugsg3-d0cf13ca3424/status/#",
         "shellyplugpmg3-907069519650/status/#",
         "shellyplugpmg3-9070695c1d18/status/#"
       ]


### PR DESCRIPTION
## What changed

- Subscribe Telegraf's Shelly MQTT consumer to `shellyplugsg3-d0cf13ca3424/status/#`.

## Why

The new Shelly Plug S Gen3 publishes under this device-specific topic, but Telegraf did not subscribe to it, so its telemetry could not reach VictoriaMetrics.

## Impact

After Argo CD reconciles the merged chart, numeric Shelly status fields should be ingested as `shelly_*` metrics with the device topic label.

## Validation

- `git diff --check`
- locked Helm dependency build (`telegraf` chart 1.8.73)
- `helm lint`
- rendered `telegraf-shelly-mqtt` ConfigMap contains the new topic
- pre-deploy VictoriaMetrics query returns no matching series (expected baseline)
