### PR TITLE
Use generic Shelly MQTT subscription

### DIFF
--- a/telegraf/templates/configmap-shelly-mqtt.yaml
+++ b/telegraf/templates/configmap-shelly-mqtt.yaml
@@ -11,20 +11,7 @@ data:
     [[inputs.mqtt_consumer]]
       name_override = "shelly"
       servers = ["tcp://mosquitto:1883"]
-      topics = [
-        "shellypro3em-2cbcbbb2ddb8/status/#",
-        "shellypro3em63-3c8a1fd182e0/status/#",
-        "shellyplugsg3-8cbfea9fd6c8/status/#",
-        "shellyplus1pm-a8032ab9d8e4/status/#",
-        "shellypmmini-543204b695cc/status/#",
-        "shelly1pmminig4-ccba97c4e854/status/#",
-        "shelly1pmminig4-ccba97c65f18/status/#",
-        "shellypill-d885ac1a6284/status/#",
-        "shelly3em63g3-e4b063f32e48/status/#",
-        "shellyplugsg3-d0cf13d87ed8/status/#",
-        "shellyplugsg3-d0cf13c856a0/status/#",
-        "shellyplugsg3-d0cf13ca3424/status/#",
-        "shellyplugpmg3-907069519650/status/#",
-        "shellyplugpmg3-9070695c1d18/status/#"
-      ]
+      topics = ["+/status/#"]
+      topic_tag = "topic"
+      tagpass = { topic = ["shelly*/status", "shelly*/status/*"] }
       data_format = "json"


### PR DESCRIPTION
## What changed

- Replace the per-device Shelly MQTT topic list with `+/status/#`.
- Explicitly retain the incoming MQTT topic as the `topic` tag.
- Emit only metrics whose topic matches the existing Shelly prefix contract.

## Why

Every new Shelly currently requires a repository change even though all Gen2+ devices publish compatible JSON below their device-specific `status` path.

## Impact

New Shelly devices using the existing default topic-prefix pattern are collected without another Telegraf change. Existing VictoriaMetrics topic labels remain unchanged.

## Validation

- `git diff --check`
- locked Helm dependency build (`telegraf` chart 1.8.73)
- `helm lint`
- rendered `telegraf-shelly-mqtt` ConfigMap contains the wildcard, explicit topic tag, and Shelly tag filter

Live Argo CD and VictoriaMetrics validation will follow after merge.
