### PR TITLE
Safely parse generic Shelly MQTT payloads

### DIFF
--- a/telegraf/templates/configmap-shelly-mqtt.yaml
+++ b/telegraf/templates/configmap-shelly-mqtt.yaml
@@ -9,9 +9,28 @@ data:
   shelly-mqtt.conf: |-
     # Shelly Smart Devices via MQTT
     [[inputs.mqtt_consumer]]
-      name_override = "shelly"
+      name_override = "shelly_raw"
       servers = ["tcp://mosquitto:1883"]
       topics = ["+/status/#"]
       topic_tag = "topic"
+      data_format = "value"
+      data_type = "string"
+
+    # Parse Shelly payloads after MQTT ingestion. Reading every candidate as a
+    # string first prevents unrelated */status/# payloads from reaching the JSON
+    # parser; the remaining shelly_raw measurements are dropped by the output.
+    [[processors.parser]]
+      order = 1
       tagpass = { topic = ["shelly*/status", "shelly*/status/*"] }
+      parse_fields = ["value"]
+      drop_original = true
+      merge = "parent"
       data_format = "json"
+
+    # The parent merge preserves the MQTT topic tag. Remove its temporary raw
+    # string field and restore the stable shelly measurement name afterward.
+    [[processors.override]]
+      order = 2
+      tagpass = { topic = ["shelly*/status", "shelly*/status/*"] }
+      name_override = "shelly"
+      fieldexclude = ["value"]

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -47,6 +47,7 @@ telegraf:
           database: "victoriametrics"
           skip_database_creation: true
           exclude_retention_policy_tag: true
+          namedrop: ["shelly_raw"]
           content_encoding: "gzip"
 
   args:


### PR DESCRIPTION
## Summary
- ingest generic `+/status/#` candidates as strings before parsing
- parse and rename only Shelly topics, preserving the existing `shelly_*` metric contract
- drop all remaining raw candidate measurements before VictoriaMetrics

## Verification
- `helm dependency build telegraf`
- `helm lint telegraf`
- `helm template telegraf telegraf`
- live isolated Telegraf test: Shelly JSON emitted, unrelated text payload dropped