### PR TITLE
Preserve Shelly MQTT delivery tracking

### DIFF
--- a/telegraf/templates/configmap-shelly-mqtt.yaml
+++ b/telegraf/templates/configmap-shelly-mqtt.yaml
@@ -18,17 +18,17 @@ data:
 
     # Parse Shelly payloads after MQTT ingestion. Reading every candidate as a
     # string first prevents unrelated */status/# payloads from reaching the JSON
-    # parser; the remaining shelly_raw measurements are dropped by the output.
+    # parser. Merge into the tracked parent metric so MQTT delivery is confirmed
+    # exactly once; remaining shelly_raw metrics go to the discard output.
     [[processors.parser]]
       order = 1
       tagpass = { topic = ["shelly*/status", "shelly*/status/*"] }
       parse_fields = ["value"]
-      drop_original = true
-      merge = "parent"
+      merge = "override"
       data_format = "json"
 
-    # The parent merge preserves the MQTT topic tag. Remove its temporary raw
-    # string field and restore the stable shelly measurement name afterward.
+    # Remove the temporary raw string field and restore the stable shelly
+    # measurement name after parsing.
     [[processors.override]]
       order = 2
       tagpass = { topic = ["shelly*/status", "shelly*/status/*"] }

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -49,6 +49,8 @@ telegraf:
           exclude_retention_policy_tag: true
           namedrop: ["shelly_raw"]
           content_encoding: "gzip"
+      - discard:
+          namepass: ["shelly_raw"]
 
   args:
     - --config


### PR DESCRIPTION
## Summary
- merge parsed Shelly fields into the original tracked MQTT metric
- route unmatched raw status messages to Telegraf discard output
- keep raw candidates out of VictoriaMetrics while confirming delivery exactly once

## Verification
- `helm lint telegraf`
- `helm template telegraf telegraf`
- isolated live test with Shelly JSON plus three non-JSON messages: one Shelly metric, zero errors